### PR TITLE
[U8] hypotheses de calcul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 1.13.1 (21/07/2023)
+
+* U8 - hypotheses de calcul
+
 ## 1.13.0 (20/07/2023)
 
 * U11 - livraison, telechargement partie conseil

--- a/src/components/base/Modal2.js
+++ b/src/components/base/Modal2.js
@@ -1,30 +1,35 @@
+import FocusTrap from "focus-trap-react";
 import React from "react";
 import styled from "styled-components";
 
 export default function Modal2(props) {
   return (
-    <Wrapper open={props.open}>
-      <Background open={props.open} onClick={() => props.setOpen(false)} />
-      <Content
-        open={props.open}
-        width={props.width}
-        textColor={props.textColor}
-        backgroundColor={props.backgroundColor}
-        noAnimation={props.noAnimation}
-      >
-        <Header>
-          {props.getTitle ? props.getTitle() : "Titre"}
-          <ButtonClose onClick={() => props.setOpen(false)}>
-            Fermer
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-              <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z" />
-            </svg>
-          </ButtonClose>
-        </Header>
+    props.open && (
+      <FocusTrap focusTrapOptions={{ initialFocus: "#button-close" }}>
+        <Wrapper open={props.open}>
+          <Background open={props.open} onClick={() => props.setOpen(false)} />
+          <Content
+            open={props.open}
+            width={props.width}
+            textColor={props.textColor}
+            backgroundColor={props.backgroundColor}
+            noAnimation={props.noAnimation}
+          >
+            <Header>
+              {props.getTitle ? props.getTitle() : "Titre"}
+              <ButtonClose onClick={() => props.setOpen(false)} id="button-close">
+                Fermer
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                  <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z" />
+                </svg>
+              </ButtonClose>
+            </Header>
 
-        <Scroll className={props.className}>{props.children}</Scroll>
-      </Content>
-    </Wrapper>
+            <Scroll className={props.className}>{props.children}</Scroll>
+          </Content>
+        </Wrapper>
+      </FocusTrap>
+    )
   );
 }
 
@@ -76,12 +81,19 @@ const Content = styled.div`
   width: ${(props) => props.width || "40em"};
 `;
 
-const ButtonClose = styled.div`
+const ButtonClose = styled.button`
   align-items: center;
+  background: inherit;
+  border: none;
   cursor: pointer;
   display: flex;
   > svg {
     margin-left: 0.5rem;
+  }
+  &:focus {
+    border-radius: 2pt;
+    outline: solid;
+    outline-color: revert;
   }
 `;
 

--- a/src/components/base/Modal2.js
+++ b/src/components/base/Modal2.js
@@ -85,6 +85,7 @@ const ButtonClose = styled.button`
   align-items: center;
   background: inherit;
   border: none;
+  color: ${(props) => props.theme.colors.text};
   cursor: pointer;
   display: flex;
   > svg {

--- a/src/components/layout/Web2.js
+++ b/src/components/layout/Web2.js
@@ -13,7 +13,7 @@ export default function Web2(props) {
 
   return (
     <>
-      <VerticalContainer>
+      <VerticalContainer className={props.theme === "night" ? "bl" : "r"}>
         <Seo title={props.title} description={props.description} image={"metalivraison.png"} />
         <Header2 />
         <BreadCrumb2 breadcrumb={props.breadcrumb} />

--- a/src/components/livraison/ResultatLivraison.js
+++ b/src/components/livraison/ResultatLivraison.js
@@ -5,7 +5,7 @@ import React, { useContext } from "react";
 import styled from "styled-components";
 
 export default function ResultatLivraison(props) {
-  const { setCo2e } = useContext(ModalContext);
+  const { setHypothesisLivraison } = useContext(ModalContext);
 
   return (
     <Wrapper>
@@ -38,7 +38,7 @@ export default function ResultatLivraison(props) {
           <div className="item5"></div>
           <div className="item6">
             <UnderstandLink>
-              <ButtonLink onClick={() => setCo2e(true)}>Comprendre le calcul</ButtonLink>
+              <ButtonLink onClick={() => setHypothesisLivraison(true)}>Comprendre le calcul</ButtonLink>
             </UnderstandLink>
           </div>
         </BlueGrid>

--- a/src/components/modals/Co2eModal2.js
+++ b/src/components/modals/Co2eModal2.js
@@ -1,4 +1,5 @@
 import Modal2 from "components/base/Modal2";
+import ExplainArrowContainer from "components/modals/ExplainArrowContainer.js";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
 import styled from "styled-components";
@@ -18,12 +19,18 @@ export default function Co2eModal2() {
   const { Co2e: open, setCo2e: setOpen } = useContext(ModalContext);
   return (
     <Modal2 open={open} setOpen={setOpen} getTitle={getTitle} width="50rem">
-      <h2>Les hypothèses retenues pour la livraison de colis </h2>
-      <p>L'ensemble des calculs sont issus de ...</p>
-      <h3>Pour les colis : </h3>
-      <p>On considère que...</p>
-      <h3>Pour les modes de transports :</h3>
-      <p>On considère que ...</p>
+      <Text>
+        Le dérèglement climatique actuel est une conséquence de nos émissions importantes de différents gaz à effet de
+        serre. Nous pouvons mesurer ces émissions avec un indice simple : les kilogrammes d&apos;équivalent CO
+        <sub>2</sub> (kgCO<sub>2</sub>e).
+      </Text>
+      <Text>
+        <strong>
+          Chaque gaz à effet est de serre est ramené à un équivalent en CO
+          <sub>2</sub> selon son pouvoir de réchauffement.
+        </strong>
+      </Text>
+      <ExplainArrowContainer></ExplainArrowContainer>
     </Modal2>
   );
 }
@@ -34,4 +41,9 @@ const GreenText = styled.span`
 
 const Title = styled.h2`
   margin: 1rem 0;
+`;
+
+const Text = styled.p`
+  margin-bottom: 2rem;
+  margin-top: 0;
 `;

--- a/src/components/modals/Co2eModal2.js
+++ b/src/components/modals/Co2eModal2.js
@@ -1,5 +1,4 @@
 import Modal2 from "components/base/Modal2";
-import ExplainArrowContainer from "components/modals/ExplainArrowContainer.js";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
 import styled from "styled-components";
@@ -19,18 +18,12 @@ export default function Co2eModal2() {
   const { Co2e: open, setCo2e: setOpen } = useContext(ModalContext);
   return (
     <Modal2 open={open} setOpen={setOpen} getTitle={getTitle} width="50rem">
-      <Text>
-        Le dérèglement climatique actuel est une conséquence de nos émissions importantes de différents gaz à effet de
-        serre. Nous pouvons mesurer ces émissions avec un indice simple : les kilogrammes d&apos;équivalent CO
-        <sub>2</sub> (kgCO<sub>2</sub>e).
-      </Text>
-      <Text>
-        <strong>
-          Chaque gaz à effet est de serre est ramené à un équivalent en CO
-          <sub>2</sub> selon son pouvoir de réchauffement.
-        </strong>
-      </Text>
-      <ExplainArrowContainer></ExplainArrowContainer>
+      <h2>Les hypothèses retenues pour la livraison de colis </h2>
+      <p>L'ensemble des calculs sont issus de ...</p>
+      <h3>Pour les colis : </h3>
+      <p>On considère que...</p>
+      <h3>Pour les modes de transports :</h3>
+      <p>On considère que ...</p>
     </Modal2>
   );
 }
@@ -41,9 +34,4 @@ const GreenText = styled.span`
 
 const Title = styled.h2`
   margin: 1rem 0;
-`;
-
-const Text = styled.p`
-  margin-bottom: 2rem;
-  margin-top: 0;
 `;

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -23,17 +23,17 @@ export default function DetailLivraisonModal2() {
         <MagicLink to="https://librairie.ademe.fr/mobilite-et-transport/6261-e-commerce-modelisation-des-impacts-et-recommandations-filieres-et-grand-public.html">
           l’étude Commerce en ligne - 2023
         </MagicLink>{" "}
-        à destination des professionels du E-commerce. L'outil ECEL (LIEN ?) à l'origine des calculs de cette étude a
-        été adapté au contexte des particuliers.
+        à destination des professionels du E-commerce. L'outil ECEL à l'origine des calculs de cette étude a été adapté
+        au contexte des particuliers sous forme de simulateur.
       </p>
       <h3>Les différents type de produits</h3>
       <p>
         L'<b>habillement</b> correspond à un produit textile qui va de la paire de chaussures, au manteau en passant par
         le t-shirt. Par défaut, nous considérons une <b>boite à chaussures</b>. Les <b>produits culturels</b>{" "}
-        correspondent aux livres, jeux de société, CD/vinyles, jeux vidéos… Par défaut, nous considérons un <b>livre</b>
-        . Les <b>équipements volumineux</b> correspondent aux gros électroménagers, l'ameublement… Par défaut, nous
-        considérons un <b>lave-vaisselle</b>.Pour <b>les produits de grande consommation</b>, nous avons considéré un
-        carton de <b>produits secs de supermarchés</b>.
+        correspondent aux livres, jeux de société, CD/vinyles, jeux vidéos, etc. Par défaut, nous considérons un{" "}
+        <b>livre</b>. Les <b>équipements volumineux</b> correspondent aux gros électroménagers, l'ameublement, etc. Par
+        défaut, nous considérons un <b>lave-vaisselle</b>.Pour <b>les produits de grande consommation</b>, nous avons
+        considéré un carton de <b>produits secs de supermarchés</b>.
       </p>
       <h3>Les scénarios de livraison</h3>
       <p>
@@ -43,18 +43,17 @@ export default function DetailLivraisonModal2() {
       </p>
       <p>
         Pour chaque scénario, nous prenons en compte l'<b>ensemble des étapes d'un processus de livraison</b> : commande
-        en ligne, emballage, entrepôt de stockage, plateformes de tri, transport inter-platerformes mais également
-        l'infrastruture de collecte et le déplacement consommateur dans le cas d'une livraison en point relais ou click
-        & collect (<i>Voir ci-dessous pour le détail de scénarios</i>). Pour un article <b>"qui vient de loin"</b>, nous
-        avons fait l'hypothèse que le colis arrive <b>par avion depuis la Chine</b> via une étpae de transport
+        en ligne, emballage, entrepôt de stockage, plateformes de tri, transport inter-platerformes, l'infrastruture de
+        collecte, et enfin, le déplacement consommateur dans le cas d'une livraison en point relais ou click & collect (
+        <i>Voir ci-dessous pour le détail des processus de livraison</i>). Pour un article <b>"qui vient de loin"</b>,
+        nous avons fait l'hypothèse que le colis arrive <b>par avion depuis la Chine</b> via une étape de transport
         supplémentaire (9000km parcourus par avion, mix électrique de l'entrepôt de départ adapté).{" "}
       </p>
       <h3>Des informations supplémentaires sur les paramètres...</h3>
       <p>
-        Pour le processus de <b>comande en ligne</b>, le type de produit impacte le temps de recherche web et donc
-        l'empreinte de l'utilisation du terminal pour effectuer effectuer l'achat. Néanmoins, les différences se jouent
-        au centième de grammes de CO2... On conserve donc une valeur unique (5,4 gCO2e) par commande quel que soit le
-        produit.
+        Pour le processus de <b>commande en ligne</b>, le type de produit impacte le temps de recherche web et donc
+        l'empreinte de l'utilisation du terminal pour effectuer effectuer l'achat. On conserve donc une valeur unique
+        (5,4 gCO2e) par commande quel que soit le produit.
       </p>
       <p>
         Un <b>emballage carton</b> a été attribué à chaque type de colis selon sa taille.
@@ -83,12 +82,12 @@ export default function DetailLivraisonModal2() {
             Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 1</li>
           <li>
             Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 2</li>
           <li>
             Transport plateforme 2 - domicile: 70 km (VUL, taux de remplissage de 15% et un taux de retour à vide de 20%
             roulant à une vitesse moyenne de 30 km/h)
@@ -101,25 +100,22 @@ export default function DetailLivraisonModal2() {
         </summary>
         <ul>
           <li>Processus de commande en ligne</li>
-          <li>
-            Entrepôt initial de stockage et de préparation du colis (emballé et stocké entre 15 et 40 jours dans un
-            entrepôt de 10000 m2)
-          </li>
+          <li>Entrepôt initial de stockage et de préparation du colis</li>
           <li>
             Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 1</li>
           <li>
             Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 2</li>
           <li>
             Transport plateforme 2 - point de retrait: 70 km (VUL, taux de remplissage de 15% et un taux de retour à
             vide de 20% roulant à une vitesse moyenne de 30 km/h)
           </li>
-          <li>Point de retrait (stocké 1 jour dans une enseigne type "magasin traditionnel" de 10 m2)</li>
+          <li>Point de retrait</li>
           <li>Déplacement consommateur</li>
         </ul>
       </details>
@@ -129,20 +125,17 @@ export default function DetailLivraisonModal2() {
         </summary>
         <ul>
           <li>Processus de commande en ligne</li>
-          <li>
-            Entrepôt initial de stockage et de préparation du colis (emballé et stocké entre 15 et 40 jours dans un
-            entrepôt de 10000 m2)
-          </li>
+          <li>Entrepôt initial de stockage et de préparation du colis</li>
           <li>
             Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 1</li>
           <li>
             Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
             retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
           </li>
-          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>Plateforme 2</li>
           <li>
             Transport plateforme 2 - magasin: 70 km (VUL, taux de remplissage de 15% et un taux de retour à vide de 20%
             roulant à une vitesse moyenne de 30 km/h)

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -12,7 +12,7 @@ export default function DetailLivraisonModal2() {
   };
   const { hypothesisLivraison: open, setHypothesisLivraison: setOpen } = useContext(ModalContext);
   return (
-    <Modal2 open={open} setOpen={setOpen} getTitle={getTitle}>
+    <Modal2 open={open} setOpen={setOpen} getTitle={getTitle} width={"80em"}>
       <p>
         L'ensemble des calculs sont issus de{" "}
         <MagicLink to="https://librairie.ademe.fr/mobilite-et-transport/6261-e-commerce-modelisation-des-impacts-et-recommandations-filieres-et-grand-public.html">

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -7,6 +7,7 @@ import styled from "styled-components";
 const Title = styled.h2``;
 
 const DetailsTitle = styled.h4`
+  cursor: pointer;
   display: inline;
 `;
 

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -6,6 +6,10 @@ import styled from "styled-components";
 
 const Title = styled.h2``;
 
+const DetailsTitle = styled.h4`
+  display: inline;
+`;
+
 export default function DetailLivraisonModal2() {
   const getTitle = () => {
     return <Title>Les hypothèses retenues</Title>;
@@ -32,23 +36,120 @@ export default function DetailLivraisonModal2() {
       </p>
       <h3>Les scénarios de livraison</h3>
       <p>
+        Dans cette première version, 3 scénarios sont proposés: la livraison{" "}
+        <b> à domicile, en point relais ou en click & collect</b>, tous adaptables à l'option{" "}
+        <b>"colis qui vient de loin"</b>.
+      </p>
+      <p>
         Pour chaque scénario, nous prenons en compte l'<b>ensemble des étapes d'un processus de livraison</b> : commande
         en ligne, emballage, entrepôt de stockage, plateformes de tri, transport inter-platerformes mais également
-        l'infrastruture de collecte et le déplacement consommateur dans le cas d'une livraison en point relais, click
-        and collect ou achat en magasin traditionnel. (Pour l'achat en magasin traditionnel, sont exclues les étapes de
-        commande en ligne et d'emballage). Nous avons fait l'hypothèse que la livraison se fait depuis un entrepôt
-        français Pour un article "qui vient de loin", nous avons fait l'hypothèse que le colis arrive par avion depuis
-        la Chine.
+        l'infrastruture de collecte et le déplacement consommateur dans le cas d'une livraison en point relais ou click
+        & collect (<i>Voir ci-dessous pour le détail de scénarios</i>). Pour un article <b>"qui vient de loin"</b>, nous
+        avons fait l'hypothèse que le colis arrive <b>par avion depuis la Chine</b> via une étpae de transport
+        supplémentaire (9000km parcourus par avion, mix électrique de l'entrepôt de départ adapté).{" "}
       </p>
-      <h3>Et d'autres paramètres...</h3>
+      <h3>Des informations supplémentaires sur les paramètres...</h3>
+      <p>
+        Pour le processus de <b>comande en ligne</b>, le type de produit impacte le temps de recherche web et donc
+        l'empreinte de l'utilisation du terminal pour effectuer effectuer l'achat. Néanmoins, les différences se jouent
+        au centième de grammes de CO2... On conserve donc une valeur unique (5,4 gCO2e) par commande quel que soit le
+        produit.
+      </p>
       <p>
         Un <b>emballage carton</b> a été attribué à chaque type de colis selon sa taille.
       </p>
       <p>
-        En ce qui concerne les <b>camions de livraison, pour le transport longue distance</b>, nous avons considéré un
+        Pour les étapes de <b>stockage</b> en entrepôt, on considère un entrepôt de 10 000 m2. Le nombre de jour de
+        stockage dépend du type de produit.
+      </p>
+      <p>
+        En ce qui concerne les <b>camions de livraison</b>, pour le transport longue distance, nous avons considéré un
         poids lourd moyen (type 44 tonnes) tandis que pour les derniers kilomètres de livraison, nous avons considéré un
         véhicule utilisaire léger.{" "}
       </p>
+      <h3>Le détails des processus</h3>
+      <details>
+        <summary>
+          <DetailsTitle>Livraison à domicile</DetailsTitle>
+        </summary>
+        <ul>
+          <li>Processus de commande en ligne</li>
+          <li>
+            Entrepôt initial de stockage et de préparation du colis (emballé et stocké entre 15 et 40 jours dans un
+            entrepôt de 10000 m2)
+          </li>
+          <li>
+            Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 2 - domicile: 70 km (VUL, taux de remplissage de 15% et un taux de retour à vide de 20%
+            roulant à une vitesse moyenne de 30 km/h)
+          </li>
+        </ul>
+      </details>
+      <details>
+        <summary>
+          <DetailsTitle>Livraison en point relais</DetailsTitle>
+        </summary>
+        <ul>
+          <li>Processus de commande en ligne</li>
+          <li>
+            Entrepôt initial de stockage et de préparation du colis (emballé et stocké entre 15 et 40 jours dans un
+            entrepôt de 10000 m2)
+          </li>
+          <li>
+            Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 2 - point de retrait: 70 km (VUL, taux de remplissage de 15% et un taux de retour à
+            vide de 20% roulant à une vitesse moyenne de 30 km/h)
+          </li>
+          <li>Point de retrait (stocké 1 jour dans une enseigne type "magasin traditionnel" de 10 m2)</li>
+          <li>Déplacement consommateur</li>
+        </ul>
+      </details>
+      <details>
+        <summary>
+          <DetailsTitle>Livraison en click & collect</DetailsTitle>
+        </summary>
+        <ul>
+          <li>Processus de commande en ligne</li>
+          <li>
+            Entrepôt initial de stockage et de préparation du colis (emballé et stocké entre 15 et 40 jours dans un
+            entrepôt de 10000 m2)
+          </li>
+          <li>
+            Transport entrepôt - plateforme 1: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 1 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 1 - plateforme 2: 400 km (poids lourd moyen, taux de remplissage de 15% et un taux de
+            retour à vide de 20% roulant à une vitesse moyenne de 60 km/h)
+          </li>
+          <li>Plateforme 2 (stocké 1 jour dans un entrepôt de 10000 m2)</li>
+          <li>
+            Transport plateforme 2 - magasin: 70 km (VUL, taux de remplissage de 15% et un taux de retour à vide de 20%
+            roulant à une vitesse moyenne de 30 km/h)
+          </li>
+          <li>Magasin (stocké 28 jours dans une enseigne type "supermarchés" de 2000 m2)</li>
+          <li>Déplacement consommateur</li>
+        </ul>
+      </details>
     </Modal2>
   );
 }

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -1,17 +1,54 @@
+import MagicLink from "components/base/MagicLink";
 import Modal2 from "components/base/Modal2";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
+import styled from "styled-components";
+
+const Title = styled.h2``;
 
 export default function DetailLivraisonModal2() {
-  const { hypothesis: open, setHypothesis: setOpen } = useContext(ModalContext);
+  const getTitle = () => {
+    return <Title>Les hypothèses retenues</Title>;
+  };
+  const { hypothesisLivraison: open, setHypothesisLivraison: setOpen } = useContext(ModalContext);
   return (
-    <Modal2 open={open} setOpen={setOpen}>
-      <h2>Les hypothèses retenues pour la livraison de colis </h2>
-      <p>L'ensemble des calculs sont issus de ...</p>
-      <h3>Pour les colis : </h3>
-      <p>On considère que...</p>
-      <h3>Pour les modes de transports :</h3>
-      <p>On considère que ...</p>
+    <Modal2 open={open} setOpen={setOpen} getTitle={getTitle}>
+      <p>
+        L'ensemble des calculs sont issus de{" "}
+        <MagicLink to="https://librairie.ademe.fr/mobilite-et-transport/6261-e-commerce-modelisation-des-impacts-et-recommandations-filieres-et-grand-public.html">
+          l’étude Commerce en ligne - 2023
+        </MagicLink>{" "}
+        à destination des professionels du E-commerce. L'outil ECEL (LIEN ?) à l'origine des calculs de cette étude a
+        été adapté au contexte des particuliers.
+      </p>
+      <h3>Les différents type de produits</h3>
+      <p>
+        L'<b>habillement</b> correspond à un produit textile qui va de la paire de chaussures, au manteau en passant par
+        le t-shirt. Par défaut, nous considérons une <b>boite à chaussures</b>. Les <b>produits culturels</b>{" "}
+        correspondent aux livres, jeux de société, CD/vinyles, jeux vidéos… Par défaut, nous considérons un <b>livre</b>
+        . Les <b>équipements volumineux</b> correspondent aux gros électroménagers, l'ameublement… Par défaut, nous
+        considérons un <b>lave-vaisselle</b>.Pour <b>les produits de grande consommation</b>, nous avons considéré un
+        carton de <b>produits secs de supermarchés</b>.
+      </p>
+      <h3>Les scénarios de livraison</h3>
+      <p>
+        Pour chaque scénario, nous prenons en compte l'<b>ensemble des étapes d'un processus de livraison</b> : commande
+        en ligne, emballage, entrepôt de stockage, plateformes de tri, transport inter-platerformes mais également
+        l'infrastruture de collecte et le déplacement consommateur dans le cas d'une livraison en point relais, click
+        and collect ou achat en magasin traditionnel. (Pour l'achat en magasin traditionnel, sont exclues les étapes de
+        commande en ligne et d'emballage). Nous avons fait l'hypothèse que la livraison se fait depuis un entrepôt
+        français Pour un article "qui vient de loin", nous avons fait l'hypothèse que le colis arrive par avion depuis
+        la Chine.
+      </p>
+      <h3>Et d'autres paramètres...</h3>
+      <p>
+        Un <b>emballage carton</b> a été attribué à chaque type de colis selon sa taille.
+      </p>
+      <p>
+        En ce qui concerne les <b>camions de livraison, pour le transport longue distance</b>, nous avons considéré un
+        poids lourd moyen (type 44 tonnes) tandis que pour les derniers kilomètres de livraison, nous avons considéré un
+        véhicule utilisaire léger.{" "}
+      </p>
     </Modal2>
   );
 }

--- a/src/components/modals/DetailLivraisonModal2.js
+++ b/src/components/modals/DetailLivraisonModal2.js
@@ -1,0 +1,17 @@
+import Modal2 from "components/base/Modal2";
+import ModalContext from "components/providers/ModalProvider";
+import React, { useContext } from "react";
+
+export default function DetailLivraisonModal2() {
+  const { hypothesis: open, setHypothesis: setOpen } = useContext(ModalContext);
+  return (
+    <Modal2 open={open} setOpen={setOpen}>
+      <h2>Les hypothèses retenues pour la livraison de colis </h2>
+      <p>L'ensemble des calculs sont issus de ...</p>
+      <h3>Pour les colis : </h3>
+      <p>On considère que...</p>
+      <h3>Pour les modes de transports :</h3>
+      <p>On considère que ...</p>
+    </Modal2>
+  );
+}

--- a/src/components/modals/ReduireModal3.js
+++ b/src/components/modals/ReduireModal3.js
@@ -8,8 +8,8 @@ import ModalContext from "components/providers/ModalProvider";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
-const href = `${process.env.NEXT_PUBLIC_SITE_URL.includes("localhost") ? "http" : "https"}://${
-  process.env.NEXT_PUBLIC_SITE_URL
+const href = `${process?.env?.NEXT_PUBLIC_SITE_URL?.includes("localhost") ? "http" : "https"}://${
+  process?.env?.NEXT_PUBLIC_SITE_URL
 }/livraison#ressource`;
 
 const getTitle = () => {

--- a/src/components/providers/ModalProvider.js
+++ b/src/components/providers/ModalProvider.js
@@ -1,4 +1,5 @@
 import Co2eModal2 from "components/modals/Co2eModal2";
+import DetailLivraisonModal2 from "components/modals/DetailLivraisonModal2";
 import DetailsUsagesNumModal from "components/modals/DetailsUsagesNumModal";
 import DevicesModal from "components/modals/DevicesModal";
 import EcvModal from "components/modals/EcvModal";
@@ -23,6 +24,7 @@ export function ModalProvider(props) {
   const [ifl, setIfl] = useState(false); //Ifl == IFrameLivraison
   const [devices, setDevices] = useState(false);
   const [hypothesis, setHypothesis] = useState(false);
+  const [hypothesisLivraison, setHypothesisLivraison] = useState(false);
 
   return (
     <ModalContext.Provider
@@ -77,6 +79,11 @@ export function ModalProvider(props) {
           window?._paq?.push(["trackEvent", "Interaction", "Modal", "Hypothèses usages numériques"]);
           setHypothesis(value);
         },
+        hypothesisLivraison,
+        setHypothesisLivraison: (value) => {
+          window?._paq?.push(["trackEvent", "Interaction", "Modal", "Hypothèses livraison"]);
+          setHypothesisLivraison(value);
+        },
       }}
     >
       {props.children}
@@ -90,6 +97,7 @@ export function ModalProvider(props) {
       <EcvModal />
       <DevicesModal />
       <DetailsUsagesNumModal />
+      <DetailLivraisonModal2 />
     </ModalContext.Provider>
   );
 }

--- a/tests/impact_livraison.spec.js
+++ b/tests/impact_livraison.spec.js
@@ -84,10 +84,10 @@ test("U4 - Equivalences", async ({ page }) => {
 
   await test.step("Une modale d'explication s'affiche", async () => {
     // Given
-    await expect(page.getByText("Comprendre l'équivalent CO2 (CO2e)Fermer")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Fermer" })).not.toBeVisible();
     // When
     await page.getByRole("button", { name: "Comprendre le calcul" }).click();
     // Then
-    await expect(page.getByText("Comprendre l'équivalent CO2 (CO2e)Fermer")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Fermer" })).toBeVisible();
   });
 });


### PR DESCRIPTION
### User Story

En tant que relais je veux pouvoir facilement comprendre et valider la donnée grâce aux hypothèses de calcul utilisées dans le calculateur et tracer aussi la source des données, ainsi que leur date de mise à jour.

## Checklist

- [x]  J’ai bien accès à la source des données sous le titre de la page, via un lien sortant qui s’ouvre dans une autre fenêtre du navigateur, comme ci-dessous :

<img width="593" alt="Screenshot 2023-07-17 at 09 26 41" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/a4daf996-3a46-4c58-a275-59aad323fa51">

    
- [x]  J’ai accès à la date de la dernière mise à jour des données à côté du lien de la source.
- [ ]  La date de la dernière mise à jour se modifie bien automatiquement lorsque les données de calcul sont modifiées dans le code.
- [ ]  J’ai bien accès aux hypothèses de calcul en cliquant sur le lien “Comprendre le calcul” dans le bloc de résultat du simulateur, comme ci-dessous :

<img width="167" alt="Screenshot 2023-07-17 at 09 27 04" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/477ce029-d094-4ca4-be68-9589dbf28a6a">


- [ ]  ~~Les hypothèses de calcul s’affichent bien sous la partie “Aller plus loin” de la modale de détail d’un calcul, sous la forme d’un lien “Voir le détail du calcul”.~~

<img width="270" alt="Screenshot 2023-07-17 at 09 27 22" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/38adcc7d-73f2-4d40-8a53-08cc2ee34c88">


- [x]  Je propose du coup : Au clic sur le lien “Comprendre le calcul” une modal s’ouvre avec l’ensemble des hypothèses utilisées dans le simulateur pour faire les calculs 
L’idée c’est d’avoir une représentation proche de ce que l’on a sur Usages Numériques  ex :
    
<img width="274" alt="Screenshot 2023-07-17 at 09 27 28" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/5b4b533a-c99f-4c35-a982-3549daea5167">

    
- [x]  Le contenu des hypothèses doit être assez **exhaustif**, **son but premier est vraiment d’engager la validité scientifique des données utilisées dans le simulateur et aussi de protéger la crédibilité de l’ADEME** puisque nous sommes partis sur des scénarios *par défaut* pour communiquer des ORDRES DE GRANDEURS. 
Chaque paramètre est propre au distributeur et d’un e-commerçant à l’autre, cela peut beaucoup varié sur l’impact.

- [x]  La rédaction du contenu peut fortement se baser sur [[le travail de scénarios](https://docs.google.com/document/d/1M_e6SGaIGP9eswYy-eDKnBdiK9N-uzXbXCduPTpYM30/edit)](https://docs.google.com/document/d/1M_e6SGaIGP9eswYy-eDKnBdiK9N-uzXbXCduPTpYM30/edit) de façon peut-être un peu simplifié. 

Ce qui me semble être important d’y figurer :
    - le simulateur est basé sur une adaptation et simplification du fichier ECEL initialement à destination des professionels du E-commerce et [[l’étude Commerce en ligne - 2023](https://librairie.ademe.fr/mobilite-et-transport/6261-e-commerce-modelisation-des-impacts-et-recommandations-filieres-et-grand-public.html)](https://librairie.ademe.fr/mobilite-et-transport/6261-e-commerce-modelisation-des-impacts-et-recommandations-filieres-et-grand-public.html)
    - Pour aller plus loin et visualiser les données : tout est ouvert et accessible sur Publicode (**lien vers le dépôt Publicode Impact Livraison qui devrait donc être dispo depuis Impact CO2)**
    - les définitions des produits que l’on peut commander
    - les scénarios de livraison
    - les autres paramètres : emballage, entrepot de stockage, transport inter-plateforme etc.
- [ ]  Au clic sur la croix, je peux fermer la modale et revenir sur le simulateur
- [ ]  Au clic sur le lien “Voir le détail du calcul”, j’accède à la documentation Publicode qui permet de détailler le calcul (côté ICO2, voir U23)