### PR TITLE
feat: BSR - agribalyse 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 1.11.5 (18/07/2023)
+
+* BSR: agribalyse 3.1
+
 ## 1.11.4 (17/07/2023)
 
 * BSR: injection de l'URL de base et de son préfixe (https)

--- a/src/components/views/equivalent/ecv/Detail.js
+++ b/src/components/views/equivalent/ecv/Detail.js
@@ -1,9 +1,7 @@
-import React, { useState } from 'react'
-import styled from 'styled-components'
-
-import { formatNumberPrecision, formatPercent } from 'utils/formatters'
-
-import ButtonLink from 'components/base/ButtonLink'
+import ButtonLink from "components/base/ButtonLink";
+import React, { useState } from "react";
+import styled from "styled-components";
+import { formatNumberPrecision, formatPercent } from "utils/formatters";
 
 const Toggle = styled(ButtonLink)`
   align-self: center;
@@ -14,7 +12,7 @@ const Toggle = styled(ButtonLink)`
   ${(props) => props.theme.mq.small} {
     margin-bottom: 2rem;
   }
-`
+`;
 const Wrapper = styled.table`
   background-color: ${(props) => props.theme.colors.second};
   border-radius: 1rem;
@@ -25,7 +23,7 @@ const Wrapper = styled.table`
     font-size: 0.75rem;
     padding: 0.25rem;
   }
-`
+`;
 const Item = styled.tr`
   td {
     padding: 0.5rem;
@@ -41,8 +39,8 @@ const Item = styled.tr`
       border: none;
     }
   }
-`
-const Label = styled.td``
+`;
+const Label = styled.td``;
 const Value = styled.td`
   font-size: 0.625em;
   font-weight: 300;
@@ -51,26 +49,38 @@ const Value = styled.td`
   strong {
     font-size: 1.6em;
   }
-`
+`;
 const Percent = styled.td`
   text-align: right;
-`
+`;
 export default function Detail(props) {
-  const [details, setDetails] = useState(false)
+  const [details, setDetails] = useState(false);
+
+  const order = [
+    "Agriculture",
+    "Transformation",
+    "Emballage",
+    "Transport",
+    "Supermarché et distribution",
+    "Consommation",
+  ];
 
   return (
     <>
-      <Toggle
-        onClick={() => setDetails((prevDetails) => !prevDetails)}
-        className='noscreenshot'
-      >
-        {details ? 'Cacher' : 'Voir'} le détail
+      <Toggle onClick={() => setDetails((prevDetails) => !prevDetails)} className="noscreenshot">
+        {details ? "Cacher" : "Voir"} le détail
       </Toggle>
       {details && (
         <Wrapper>
           <tbody>
             {props.ecv
-              .sort((a, b) => (a.value < b.value ? 1 : -1))
+              .sort((a, b) => {
+                let res = a.value < b.value ? 1 : -1;
+                if (a.label && b.label) {
+                  res = order.indexOf(a.label) > order.indexOf(b.label) ? 1 : -1;
+                }
+                return res;
+              })
               .map((item) => (
                 <Item key={item.label}>
                   <Label>{item.label}</Label>
@@ -82,7 +92,7 @@ export default function Detail(props) {
                   </Value>
                 </Item>
               ))}
-            <Item key={'total'}>
+            <Item key={"total"}>
               <Label>
                 <strong>Total</strong>
               </Label>
@@ -96,5 +106,5 @@ export default function Detail(props) {
         </Wrapper>
       )}
     </>
-  )
+  );
 }

--- a/src/data/categories/fruitsetlegumes.json
+++ b/src/data/categories/fruitsetlegumes.json
@@ -1162,7 +1162,8 @@
     }
   },
   {
-    "name": "Haricot vert importé par avion",
+    "name": "Haricot vert",
+    "subtitle": "Importé par avion",
     "Code_CIQUAL": 20061,
     "prefix": "kg de ",
     "slug": "haricotvert",

--- a/src/data/categories/fruitsetlegumes.json
+++ b/src/data/categories/fruitsetlegumes.json
@@ -1162,7 +1162,7 @@
     }
   },
   {
-    "name": "Haricot vert",
+    "name": "Haricot vert importé par avion",
     "Code_CIQUAL": 20061,
     "prefix": "kg de ",
     "slug": "haricotvert",
@@ -1204,8 +1204,8 @@
     ],
     "source": "https://agribalyse.ademe.fr/app/aliments/20061_2#Haricot_vert,_cru",
     "meta": {
-      "title": "Empreinte carbone d'un kg d'haricot vert",
-      "description": "Découvrez le détail de l'empreinte carbone d'un kg d'haricot vert : de l'agriculture à la distribution et la consommation"
+      "title": "Empreinte carbone d'un kg d'haricot vert importé par avion, cru",
+      "description": "Découvrez le détail de l'empreinte carbone d'un kg d'haricot vert importé par avion : de l'agriculture à la distribution et la consommation"
     }
   },
   {

--- a/src/data/categories/fruitsetlegumes.json
+++ b/src/data/categories/fruitsetlegumes.json
@@ -1106,7 +1106,7 @@
       10,
       11
     ],
-    "source": "https://agribalyse.ademe.fr/app/aliments/13025_1#Mangue_import%C3%A9e_par_avion,_pulpe,_crue",
+    "source": "https://agribalyse.ademe.fr/app/aliments/13025_2#Mangue_import%C3%A9e_par_avion,_pulpe,_crue",
     "meta": {
       "title": "Empreinte carbone d'une mangue",
       "description": "Découvrez le détail de l'empreinte carbone d'un kg de mangues : de l'agriculture à la distribution et la consommation"


### PR DESCRIPTION
## R7 - 17/07

Bon on ne parlera pas de mon temps perdu à recetter le mauvais lien 😅….

Mais une fois que j’étais sur le bon  j’ai fais une passe sur l’ensemble des fruits & légumes du mois, en grande majorité c’est nickel quand on croise les données. Juste quelques petites pétouilles à modifier : 

- **La Tomate** il y a encore une différence de FE ? : 0,7 vs 0,6 et les % sont pas les bons

<img width="501" alt="Screenshot 2023-07-18 at 08 12 45" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/4afd9f63-6d0c-43e5-9c2d-68ced1e7704d">


- **Haricot vert** : comme pour la mangue il faudrait préciser qu’ils sont importés par avion
    
<img width="430" alt="Screenshot 2023-07-18 at 08 13 17" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/c87b4524-06cb-4386-83ff-709497688a26">

    
- **Mangue** : c’est le mauvais lien source, on renvoie vers la Mangue importée par bateau. Hors on prend le FE de la mangue importée par avion : il faut changer le lien par [[https://agribalyse.ademe.fr/app/aliments/13025_1#Mangue_importée_par_avion,_pulpe,_crue]

- C’est de la pétouille et du détail mais dans la légende du graphique, les éléments sont parfois inversés d’un item à l’autre : on peut avoir supermarché - consommation ou consommation - supermarché (comme ci-dessous) 
**Est-ce que ce serait possible d’avoir une légende dans le même ordre pour tous les items ? La même que sur Agribalyse 🙂 ?**