### PR TITLE
feat: U10 - conseil ademe, corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## 1.12.1 (20/07/2023)
+
+* U10 - conseil ademe, corrections
+
 ## 1.12.0 (18/07/2023)
 
 * U10 - conseil ademe

--- a/src/components/livraison/AdviceLivraison.js
+++ b/src/components/livraison/AdviceLivraison.js
@@ -15,7 +15,7 @@ export default function AdviceLivraison() {
         line1Subtext="... ou utiliser son trajet domicile-travail pour éviter un trajet spécifique en voiture."
         line2Emoji="🏠"
         line2Text="Se faire livrer à domicile uniquement lorsque l'on est présent•e"
-        line2Subtext="a minima indiquer ses préférences de livraison en cas d'absence (laisser le colis à un endroit ou chez un voisin)"
+        line2Subtext="A minima indiquer ses préférences de livraison en cas d'absence (laisser le colis à un endroit ou chez un voisin)"
       />
       <br />
       <AdviceLivraisonDetail
@@ -37,8 +37,8 @@ export default function AdviceLivraison() {
         line2Text="Garder les emballages pour les réutiliser."
         line2Subtext="Vous en aurez certainement besoin si vous vendez également des objets sur des plateformes en ligne ou pour un éventuel déménagement."
         line3Emoji="♻️"
-        line3Text="Une seule commande vaut mieux que plusieurs petites."
-        line3Subtext="C’est moins de transport et moins d’emballages. D’ailleurs, pourquoi ne pas faire des achats groupés entre amis ou proches ?"
+        line3Text="Déposer les emballages non réutilisables dans les bacs de tri."
+        line3Subtext="Pour faciliter le recyclage des papiers, cartons et plastiques, respectez bien les consignes de la commune. Les emballages volumineux sont à déposer en déchèterie."
       />
     </>
   );

--- a/src/components/livraison/AdviceLivraison.js
+++ b/src/components/livraison/AdviceLivraison.js
@@ -6,7 +6,7 @@ export default function AdviceLivraison() {
   return (
     <>
       <Separator />
-      <H2Title>Conseils pour réduire son empreinte carbone</H2Title>
+      <H2Title>Conseil pour réduire l’impact carbone de vos livraisons</H2Title>
       <br />
       <AdviceLivraisonDetail
         title="Veiller au dernier km"

--- a/src/components/livraison/AdviceLivraison.js
+++ b/src/components/livraison/AdviceLivraison.js
@@ -56,7 +56,7 @@ const Separator = styled.hr`
 `;
 
 const H2Title = styled.h2`
-  font-size: 22px;
+  font-size: 1.375rem; // 22px/16px
   font-weight: 700;
   margin-bottom: 0;
   margin-top: 0;

--- a/src/components/livraison/AdviceLivraisonDetail.js
+++ b/src/components/livraison/AdviceLivraisonDetail.js
@@ -88,7 +88,10 @@ const Wrapper = styled.section`
 
 const H3Title = styled.h3`
   color: ${(props) => props.theme.colors.main3};
-  font-size: 16px;
+  font-size: 1rem;
+  ${(props) => props.theme.mq.small} {
+    font-size: 0.875rem;
+  }
   font-weight: 700;
   line-height: 24px;
   margin-left: 0.5rem;
@@ -115,13 +118,16 @@ const Icon = styled.div`
 
 const Text = styled.div`
   color: ${(props) => props.theme.colors.deepDark};
-  font-size: 16px;
+  font-size: 1rem;
+  ${(props) => props.theme.mq.small} {
+    font-size: 0.875rem;
+  }
   line-height: 24px;
 `;
 
 const Subtext = styled.div`
   color: ${(props) => props.theme.colors.textGray2};
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 16px;
 `;
 

--- a/src/components/livraison/ConclusionLivraison.js
+++ b/src/components/livraison/ConclusionLivraison.js
@@ -18,6 +18,7 @@ export default function ConclusionLivraison() {
               <SimpleText>
                 Pour plus de conseils,{" "}
                 <Link
+                  title="télécharger le guide de l’ADEME - Nouvelle fenêtre"
                   target="_blank"
                   rel="noreferrer noopener"
                   href="https://librairie.ademe.fr/cadic/4466/guide-pratique-econsommateur-responsable.pdf"

--- a/src/components/livraison/ConclusionLivraison.js
+++ b/src/components/livraison/ConclusionLivraison.js
@@ -23,6 +23,23 @@ export default function ConclusionLivraison() {
                   href="https://librairie.ademe.fr/cadic/4466/guide-pratique-econsommateur-responsable.pdf"
                 >
                   télécharger le guide de l’ADEME « E-consommateur & responsable »
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    fill="currentColor"
+                    class="bi bi-box-arrow-up-right"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"
+                    />
+                    <path
+                      fillRule="evenodd"
+                      d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"
+                    />
+                  </svg>
                 </Link>
               </SimpleText>
             </TextContainer>
@@ -47,6 +64,9 @@ const SimpleText = styled.div`
   line-height: 24px;
   > a {
     color: ${(props) => props.theme.colors.firstBlue};
+  }
+  svg {
+    margin-left: 0.25rem;
   }
 `;
 

--- a/src/components/livraison/IntroLivraison.js
+++ b/src/components/livraison/IntroLivraison.js
@@ -46,6 +46,7 @@ export default function IntroLivraison() {
           <SmallText>
             <span> Source : </span>
             <BlueLink
+              title="Commerce en ligne - Étude ADEME 2023 - Nouvelle fenêtre"
               href="https://librairie.ademe.fr/mobilite-et-transport/6261-commerce-en-ligne-impacts-environnementaux-de-la-logistique-des-transports-et-des-deplacements.html"
               target="_blank"
               data-testid="lien-etude-ademe"


### PR DESCRIPTION
### R7 - 19/07

- Le titre n’est pas le bon. Il faut le remplacer par “Conseil pour réduire l’impact carbone de vos livraisons”
- Mettre une majuscule à “A minima”
- Dans le bloc **Limiter le suremballage, il y a une coquille,** on retrouve le bulletpoint *une seule commande vaut mieux que plusieurs petites…”* alors qu’il faut intégrer la partie *“ Déposez les emballages non réutilisables dans les bacs de tri”*

- Je me demande aussi, par défaut la liste de chaque conseil est dépliée. Est-ce que pour alléger la page du site on les laisserait pas plier ? 
**Inconvénient** on perd la richesse du contenu et ça donne peut-être moins envie de le partage instinctivement tel quel 
**Avantage**, on aère beaucoup la page

<img width="605" alt="Screenshot 2023-07-20 at 10 26 21" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/e6ca563b-9d1e-4a76-b2c4-02f6cf422817">


- Ca rend bien sur mobile !

### R7 (Laura) 20/07

- **Légende des retours**
    
    ⚠️ point d’attention : à corriger
    ✅ tout fonctionne
    🔅 idée, proposition : à déterminer selon la complexité tech
    ‼️ gros bug : à corriger d’urgence (mais on en a pas là)
    
- ✅ Accessibilité : fonctionnement au clavier OK !
- ⚠️ Accessibilité :
    - Le lien vers le doc ressource nécessite une icône indiquant qu’il s’ouvre dans une autre fenêtre, comme sur la maquette. Idéalement, ajouter dans le “title” du lien le format du lien genre “Télécharger le guide de l’ADEME – Nouvelle fenêtre”.
    - Idem pour le lien tout en haut d’ailleurs, ajouter un “… – Nouvelle fenêtre” à la fin de la Source pourrait être super. :) Les autres problématiques qui remontent dans mon outil d’analyse accessibilité sont des sujets liés aux contrastes de couleurs et formats PDF. Donc pour plus tard !
- ✅ Accessibilité : dark mode OK (il n’est pas incroyable en termes d’UI mais ça fonctionne, il faudra de toute façon que je fasse des propositions plus fines à ce niveau.
- 🔅 Mobile : tout fonctionne bien, je me demande juste si on ne gagnerait pas à avoir une typo un chouïa plus petite dans les conseils : tu as ton H3 pour les titres des conseils en 16px, et donc idéalement on pourrait passer le texte qui est dans tes <div> en 14px (gros texte en face des emojis). Ex. à l’arrache avec l’inspecteur :
    
<img width="190" alt="Screenshot 2023-07-20 at 10 50 07" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/dca0a715-0896-47c1-82ee-bede94702f19">

    
- 🔅 Idée globale (pour mémo) : idéalement les typos ne sont pas en pixels mais en rem ou em pour permettre aux gens de zoomer/dézoomer. :) On pourra faire une passe ensemble @David Boureau si tu as besoin (je me base toujours sur du 16px pour le passage en rem).