### PR TITLE
U23 - modale partager V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.16.0 (01/08/2023)
+
+* U23 - modale partager V2
+
 ## 1.15.2 (31/07/2023)
 
 * A24b - amélioration des métriques

--- a/src/components/base/OutboundLink.js
+++ b/src/components/base/OutboundLink.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 export default function OutboundLink(props) {
   return (
     <>
-      <Wrapper>
+      <Wrapper color={props.color}>
         <Link
           title={props.title}
           target="_blank"
@@ -39,7 +39,9 @@ export default function OutboundLink(props) {
 
 const Wrapper = styled.span`
   > a {
-    color: ${(props) => props.theme.colors.firstBlue};
+    color: ${(props) => () => {
+      return props.color === "black" ? props.theme.colors.persistentText : props.theme.colors.firstBlue;
+    }};
   }
   svg {
     margin-left: 0.25rem;

--- a/src/components/livraison/ReuseBulb.js
+++ b/src/components/livraison/ReuseBulb.js
@@ -1,0 +1,134 @@
+import MagicLink from "components/base/MagicLink";
+import OutboundLink from "components/base/OutboundLink";
+import styled from "styled-components";
+
+export default function ReuseBulb() {
+  return (
+    <>
+      <UseBulb>
+        <UseBulbTitle>
+          <div>
+            <svg width="11" height="17" viewBox="0 0 22 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M22 10.92C22 17.359 17 18.359 17 24.36C17 27.458 13.877 27.719 11.5 27.719C9.447 27.719 4.914 26.94 4.914 24.358C4.914 18.36 0 17.36 0 10.92C0 4.889 5.285 0 11.083 0C16.883 0 22 4.889 22 10.92Z"
+                fill="#FFD983"
+              />
+              <path
+                d="M15.167 32.36C15.167 33.188 12.933 34.86 11 34.86C9.067 34.86 6.833 33.188 6.833 32.36C6.833 31.532 9.066 31.86 11 31.86C12.933 31.86 15.167 31.532 15.167 32.36Z"
+                fill="#CCD6DD"
+              />
+              <path
+                d="M15.707 10.153C15.316 9.76201 14.684 9.76201 14.293 10.153L11 13.446L7.707 10.153C7.316 9.76201 6.684 9.76201 6.293 10.153C5.902 10.544 5.902 11.176 6.293 11.567L10 15.274V25.86C10 26.413 10.448 26.86 11 26.86C11.552 26.86 12 26.413 12 25.86V15.274L15.707 11.567C16.098 11.176 16.098 10.544 15.707 10.153Z"
+                fill="#FFCC4D"
+              />
+              <path
+                d="M17 30.86C17 31.964 16.104 32.86 15 32.86H7C5.896 32.86 5 31.964 5 30.86V24.86H17V30.86Z"
+                fill="#99AAB5"
+              />
+              <path
+                d="M4.999 31.86C4.519 31.86 4.095 31.513 4.014 31.024C3.923 30.48 4.291 29.964 4.836 29.874L16.836 27.874C17.38 27.776 17.896 28.151 17.986 28.696C18.077 29.24 17.709 29.756 17.164 29.846L5.164 31.846C5.109 31.856 5.053 31.86 4.999 31.86ZM4.999 27.86C4.519 27.86 4.095 27.513 4.014 27.024C3.923 26.48 4.291 25.964 4.836 25.874L16.836 23.874C17.38 23.777 17.896 24.151 17.986 24.696C18.077 25.24 17.709 25.756 17.164 25.846L5.164 27.846C5.109 27.856 5.053 27.86 4.999 27.86Z"
+                fill="#CCD6DD"
+              />
+            </svg>
+          </div>
+          <div>&nbsp;Utiliser cette ressource</div>
+        </UseBulbTitle>
+        <p>
+          Utilisez les{" "}
+          <OutboundLink
+            color={"black"}
+            href="https://giant-carbon-bac.notion.site/Kit-de-diffusion-Impact-CO2-b9d08930a49a4346830b7a12fd7cb733"
+            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
+          >
+            kits de diffusion Impact CO2
+          </OutboundLink>{" "}
+          pour vous emparer facilement du simulateur et l’intégrer à votre site.
+        </p>
+        <p>Besoin d'inspiration?</p>
+        <p style={{ "margin-bottom": 0 }}>
+          <OutboundLink
+            color={"black"}
+            href="https://giant-carbon-bac.notion.site/2274283430e94d1db71eced54c338997?v=3edb1996a5074f658a079a97a368b61c&pvs=4"
+            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
+          >
+            Découvrez des exemples de réutilisation
+          </OutboundLink>
+        </p>
+      </UseBulb>
+      <br />
+      <GoFurther>
+        <details>
+          <summary>
+            <span>Aller plus loin</span>
+          </summary>
+          <GoFurtherFirstParagraph>
+            Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
+            à&nbsp;
+            <BlackMagicLink to="mailto:datagir@ademe.fr">datagir@ademe.fr</BlackMagicLink>.
+          </GoFurtherFirstParagraph>
+          <GoFurtherSecondParagraph>
+            Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
+            du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (<i>open source</i>).
+          </GoFurtherSecondParagraph>
+        </details>
+      </GoFurther>
+      <br />
+    </>
+  );
+}
+
+const UseBulb = styled.div`
+  background-color: #ebf2ff;
+  border-radius: 8px;
+  color: ${(props) => props.theme.colors.persistentText};
+  margin-top: 2rem;
+  padding: 24px;
+  position: relative;
+`;
+
+const UseBulbTitle = styled.div`
+  align-items: center;
+  background-color: white;
+  border: 2px solid #ebf2ff;
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 2px;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  display: flex;
+  font-weight: 500;
+  justify-content: center;
+  padding: 8px;
+  position: absolute;
+  top: -21px;
+`;
+
+const BlackMagicLink = styled(MagicLink)`
+  color: ${(props) => props.theme.colors.text};
+  > svg {
+    display: none;
+  }
+`;
+
+const GoFurther = styled.div`
+  border: 1px solid #eae5e8;
+  border-radius: 8px;
+  padding: 1rem;
+  details > summary {
+    padding-right: 1rem;
+  }
+  summary {
+    font-size: 1rem;
+    font-weight: 700;
+    span {
+      padding-left: 0.5rem;
+    }
+  }
+`;
+
+const GoFurtherFirstParagraph = styled.div`
+  margin-top: 2rem;
+`;
+
+const GoFurtherSecondParagraph = styled.div`
+  margin-top: 0.5rem;
+`;

--- a/src/components/modals/ReduireModal3.js
+++ b/src/components/modals/ReduireModal3.js
@@ -4,6 +4,7 @@ import Linkedin2 from "./shareModal/Linkedin2";
 import Twitter2 from "./shareModal/Twitter2";
 import Whatsapp2 from "./shareModal/Whatsapp2";
 import Modal3 from "components/base/Modal3";
+import ReuseBulb from "components/livraison/ReuseBulb";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
@@ -50,6 +51,8 @@ export default function ReduireModal3() {
         />
         <Linkedin2 url={href} />
       </WrapperSocial>
+      <br />
+      <ReuseBulb></ReuseBulb>
     </Modal3>
   );
 }

--- a/src/components/modals/SocialModal3.js
+++ b/src/components/modals/SocialModal3.js
@@ -4,6 +4,7 @@ import Linkedin2 from "./shareModal/Linkedin2";
 import Twitter2 from "./shareModal/Twitter2";
 import Whatsapp2 from "./shareModal/Whatsapp2";
 import Modal3 from "components/base/Modal3";
+import ReuseBulb from "components/livraison/ReuseBulb";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
@@ -48,6 +49,8 @@ export default function SocialModal3() {
         />
         <Linkedin2 url={href} />
       </WrapperSocial>
+      <br />
+      <ReuseBulb></ReuseBulb>
     </Modal3>
   );
 }

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -75,15 +75,15 @@ export default function IflConfigurator(props) {
       <GoFurther>
         <details>
           <summary>Pour aller plus loin</summary>
-          <p>
+          <GoFurtherFirstParagraph>
             Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
             à&nbsp;
             <BlackMagicLink to="mailto:datagir@ademe.fr">datagir@ademe.fr</BlackMagicLink>.
-          </p>
-          <p>
+          </GoFurtherFirstParagraph>
+          <GoFurtherSecondParagraph>
             Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
             du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (open source).
-          </p>
+          </GoFurtherSecondParagraph>
         </details>
       </GoFurther>
     </Wrapper>
@@ -134,4 +134,22 @@ const BlackMagicLink = styled(MagicLink)`
   }
 `;
 
-const GoFurther = styled.div``;
+const GoFurther = styled.div`
+  border: 1px solid #eae5e8;
+  border-radius: 8px;
+  padding: 1rem;
+  details > summary {
+    list-style-type: ">";
+  }
+  details[open] > summary {
+    list-style-type: "∨";
+  }
+`;
+
+const GoFurtherFirstParagraph = styled.div`
+  margin-top: 2rem;
+`;
+
+const GoFurtherSecondParagraph = styled.div`
+  margin-top: 0.5rem;
+`;

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -1,7 +1,6 @@
 import IflCode from "./IflCode";
-import MagicLink from "components/base/MagicLink";
-import OutboundLink from "components/base/OutboundLink";
 import Select from "components/base/Select";
+import ReuseBulb from "components/livraison/ReuseBulb";
 import React from "react";
 import styled from "styled-components";
 
@@ -21,85 +20,10 @@ export default function IflConfigurator(props) {
         <option value="night">Sombre</option>
       </Select>
       <IflCode type={props.path} theme={props.theme}></IflCode>
-      <UseBulb>
-        <UseBulbTitle>
-          <div>
-            <svg width="11" height="17" viewBox="0 0 22 35" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M22 10.92C22 17.359 17 18.359 17 24.36C17 27.458 13.877 27.719 11.5 27.719C9.447 27.719 4.914 26.94 4.914 24.358C4.914 18.36 0 17.36 0 10.92C0 4.889 5.285 0 11.083 0C16.883 0 22 4.889 22 10.92Z"
-                fill="#FFD983"
-              />
-              <path
-                d="M15.167 32.36C15.167 33.188 12.933 34.86 11 34.86C9.067 34.86 6.833 33.188 6.833 32.36C6.833 31.532 9.066 31.86 11 31.86C12.933 31.86 15.167 31.532 15.167 32.36Z"
-                fill="#CCD6DD"
-              />
-              <path
-                d="M15.707 10.153C15.316 9.76201 14.684 9.76201 14.293 10.153L11 13.446L7.707 10.153C7.316 9.76201 6.684 9.76201 6.293 10.153C5.902 10.544 5.902 11.176 6.293 11.567L10 15.274V25.86C10 26.413 10.448 26.86 11 26.86C11.552 26.86 12 26.413 12 25.86V15.274L15.707 11.567C16.098 11.176 16.098 10.544 15.707 10.153Z"
-                fill="#FFCC4D"
-              />
-              <path
-                d="M17 30.86C17 31.964 16.104 32.86 15 32.86H7C5.896 32.86 5 31.964 5 30.86V24.86H17V30.86Z"
-                fill="#99AAB5"
-              />
-              <path
-                d="M4.999 31.86C4.519 31.86 4.095 31.513 4.014 31.024C3.923 30.48 4.291 29.964 4.836 29.874L16.836 27.874C17.38 27.776 17.896 28.151 17.986 28.696C18.077 29.24 17.709 29.756 17.164 29.846L5.164 31.846C5.109 31.856 5.053 31.86 4.999 31.86ZM4.999 27.86C4.519 27.86 4.095 27.513 4.014 27.024C3.923 26.48 4.291 25.964 4.836 25.874L16.836 23.874C17.38 23.777 17.896 24.151 17.986 24.696C18.077 25.24 17.709 25.756 17.164 25.846L5.164 27.846C5.109 27.856 5.053 27.86 4.999 27.86Z"
-                fill="#CCD6DD"
-              />
-            </svg>
-          </div>
-          <div>&nbsp;Utiliser cette ressource</div>
-        </UseBulbTitle>
-        <p>
-          Utilisez les{" "}
-          <OutboundLink
-            color={"black"}
-            href="https://giant-carbon-bac.notion.site/Kit-de-diffusion-Impact-CO2-b9d08930a49a4346830b7a12fd7cb733"
-            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
-          >
-            kits de diffusion Impact CO2
-          </OutboundLink>{" "}
-          pour vous emparer facilement du simulateur et l’intégrer à votre site.
-        </p>
-        <p>Besoin d'inspiration?</p>
-        <p style={{ "margin-bottom": 0 }}>
-          <OutboundLink
-            color={"black"}
-            href="https://giant-carbon-bac.notion.site/2274283430e94d1db71eced54c338997?v=3edb1996a5074f658a079a97a368b61c&pvs=4"
-            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
-          >
-            Découvrez des exemples de réutilisation
-          </OutboundLink>
-        </p>
-      </UseBulb>
-      <br />
-      <GoFurther>
-        <details>
-          <summary>
-            <span>Aller plus loin</span>
-          </summary>
-          <GoFurtherFirstParagraph>
-            Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
-            à&nbsp;
-            <BlackMagicLink to="mailto:datagir@ademe.fr">datagir@ademe.fr</BlackMagicLink>.
-          </GoFurtherFirstParagraph>
-          <GoFurtherSecondParagraph>
-            Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
-            du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (<i>open source</i>).
-          </GoFurtherSecondParagraph>
-        </details>
-      </GoFurther>
-      <br />
+      <ReuseBulb></ReuseBulb>
     </Wrapper>
   );
 }
-
-const UseBulb = styled.div`
-  background-color: #ebf2ff;
-  border-radius: 8px;
-  margin-top: 2rem;
-  padding: 24px;
-  position: relative;
-`;
 
 const Wrapper = styled.div`
   display: flex;
@@ -112,55 +36,4 @@ const Wrapper = styled.div`
     margin-bottom: 1.5rem;
     width: 100%;
   }
-`;
-
-const UseBulbTitle = styled.div`
-  align-items: center;
-  background-color: white;
-  border: 2px solid #ebf2ff;
-  border-bottom-left-radius: 16px;
-  border-bottom-right-radius: 2px;
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
-  display: flex;
-  font-weight: 500;
-  justify-content: center;
-  padding: 8px;
-  position: absolute;
-  top: -21px;
-`;
-
-const BlackMagicLink = styled(MagicLink)`
-  color: ${(props) => props.theme.colors.text};
-  > svg {
-    display: none;
-  }
-`;
-
-const GoFurther = styled.div`
-  border: 1px solid #eae5e8;
-  border-radius: 8px;
-  padding: 1rem;
-  details > summary {
-    /* list-style-type: ">"; */
-    padding-right: 1rem;
-  }
-  /* details[open] > summary {
-    list-style-type: "v";
-  } */
-  summary {
-    font-size: 1rem;
-    font-weight: 700;
-    span {
-      padding-left: 0.5rem;
-    }
-  }
-`;
-
-const GoFurtherFirstParagraph = styled.div`
-  margin-top: 2rem;
-`;
-
-const GoFurtherSecondParagraph = styled.div`
-  margin-top: 0.5rem;
 `;

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -50,14 +50,14 @@ export default function IflConfigurator(props) {
           <div>&nbsp;Utiliser cette ressource</div>
         </GoFurther>
         <p>
-          Utilisez les
+          Utilisez les{" "}
           <OutboundLink
             color={"black"}
             href="https://giant-carbon-bac.notion.site/Kit-de-diffusion-Impact-CO2-b9d08930a49a4346830b7a12fd7cb733"
             title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
           >
             kits de diffusion Impact CO2
-          </OutboundLink>
+          </OutboundLink>{" "}
           pour vous emparer facilement du simulateur et l’intégrer à votre site.
         </p>
         <p>Besoin d'inspiration?</p>

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -50,12 +50,23 @@ export default function IflConfigurator(props) {
           <div>&nbsp;Utiliser cette ressource</div>
         </GoFurther>
         <p>
-          Utilisez les kits de diffusion Impact CO2 pour vous emparer facilement du simulateur et l’intégrer à votre
-          site.
+          Utilisez les
+          <OutboundLink
+            color={"black"}
+            href="https://giant-carbon-bac.notion.site/Kit-de-diffusion-Impact-CO2-b9d08930a49a4346830b7a12fd7cb733"
+            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
+          >
+            kits de diffusion Impact CO2
+          </OutboundLink>
+          pour vous emparer facilement du simulateur et l’intégrer à votre site.
         </p>
         <p>Besoin d'inspiration?</p>
         <p>
-          <OutboundLink href="https://example.com" title="Découvrir des exemples de réutilisation – Nouvelle fenêtre">
+          <OutboundLink
+            color={"black"}
+            href="https://giant-carbon-bac.notion.site/2274283430e94d1db71eced54c338997?v=3edb1996a5074f658a079a97a368b61c"
+            title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
+          >
             Découvrez des exemples de réutilisation
           </OutboundLink>
         </p>

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -70,6 +70,9 @@ export default function IflConfigurator(props) {
             Découvrez des exemples de réutilisation
           </OutboundLink>
         </p>
+      </BottomAdvice>
+      <details>
+        <summary>Pour aller plus loin</summary>
         <p>
           Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
           à&nbsp;
@@ -79,7 +82,7 @@ export default function IflConfigurator(props) {
           Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
           du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (open source).
         </p>
-      </BottomAdvice>
+      </details>
     </Wrapper>
   );
 }

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -20,6 +20,7 @@ export default function IflConfigurator(props) {
         <option value="night">Sombre</option>
       </Select>
       <IflCode type={props.path} theme={props.theme}></IflCode>
+      <br />
       <ReuseBulb></ReuseBulb>
     </Wrapper>
   );

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -74,7 +74,9 @@ export default function IflConfigurator(props) {
       <br />
       <GoFurther>
         <details>
-          <summary>Pour aller plus loin</summary>
+          <summary>
+            <span>Aller plus loin</span>
+          </summary>
           <GoFurtherFirstParagraph>
             Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
             à&nbsp;
@@ -82,10 +84,11 @@ export default function IflConfigurator(props) {
           </GoFurtherFirstParagraph>
           <GoFurtherSecondParagraph>
             Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
-            du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (open source).
+            du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (<i>open source</i>).
           </GoFurtherSecondParagraph>
         </details>
       </GoFurther>
+      <br />
     </Wrapper>
   );
 }
@@ -139,10 +142,18 @@ const GoFurther = styled.div`
   border-radius: 8px;
   padding: 1rem;
   details > summary {
-    list-style-type: ">";
+    /* list-style-type: ">"; */
+    padding-right: 1rem;
   }
-  details[open] > summary {
-    list-style-type: "∨";
+  /* details[open] > summary {
+    list-style-type: "v";
+  } */
+  summary {
+    font-size: 1rem;
+    font-weight: 700;
+    span {
+      padding-left: 0.5rem;
+    }
   }
 `;
 

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -21,8 +21,8 @@ export default function IflConfigurator(props) {
         <option value="night">Sombre</option>
       </Select>
       <IflCode type={props.path} theme={props.theme}></IflCode>
-      <BottomAdvice>
-        <GoFurther>
+      <UseBulb>
+        <UseBulbTitle>
           <div>
             <svg width="11" height="17" viewBox="0 0 22 35" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path
@@ -48,7 +48,7 @@ export default function IflConfigurator(props) {
             </svg>
           </div>
           <div>&nbsp;Utiliser cette ressource</div>
-        </GoFurther>
+        </UseBulbTitle>
         <p>
           Utilisez les{" "}
           <OutboundLink
@@ -61,34 +61,36 @@ export default function IflConfigurator(props) {
           pour vous emparer facilement du simulateur et l’intégrer à votre site.
         </p>
         <p>Besoin d'inspiration?</p>
-        <p>
+        <p style={{ "margin-bottom": 0 }}>
           <OutboundLink
             color={"black"}
-            href="https://giant-carbon-bac.notion.site/2274283430e94d1db71eced54c338997?v=3edb1996a5074f658a079a97a368b61c"
+            href="https://giant-carbon-bac.notion.site/2274283430e94d1db71eced54c338997?v=3edb1996a5074f658a079a97a368b61c&pvs=4"
             title="Découvrir des exemples de réutilisation – Nouvelle fenêtre"
           >
             Découvrez des exemples de réutilisation
           </OutboundLink>
         </p>
-      </BottomAdvice>
+      </UseBulb>
       <br />
-      <details>
-        <summary>Pour aller plus loin</summary>
-        <p>
-          Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
-          à&nbsp;
-          <BlackMagicLink to="mailto:datagir@ademe.fr">datagir@ademe.fr</BlackMagicLink>.
-        </p>
-        <p>
-          Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
-          du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (open source).
-        </p>
-      </details>
+      <GoFurther>
+        <details>
+          <summary>Pour aller plus loin</summary>
+          <p>
+            Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
+            à&nbsp;
+            <BlackMagicLink to="mailto:datagir@ademe.fr">datagir@ademe.fr</BlackMagicLink>.
+          </p>
+          <p>
+            Pour réutiliser <BlackMagicLink to="https://github.com/incubateur-ademe/impactco2/">le code</BlackMagicLink>{" "}
+            du simulateur, consultez le code du site Impact CO2, développé de manière ouverte (open source).
+          </p>
+        </details>
+      </GoFurther>
     </Wrapper>
   );
 }
 
-const BottomAdvice = styled.div`
+const UseBulb = styled.div`
   background-color: #ebf2ff;
   border-radius: 8px;
   margin-top: 2rem;
@@ -109,7 +111,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const GoFurther = styled.div`
+const UseBulbTitle = styled.div`
   align-items: center;
   background-color: white;
   border: 2px solid #ebf2ff;
@@ -131,3 +133,5 @@ const BlackMagicLink = styled(MagicLink)`
     display: none;
   }
 `;
+
+const GoFurther = styled.div``;

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -1,5 +1,6 @@
 import IflCode from "./IflCode";
 import MagicLink from "components/base/MagicLink";
+import OutboundLink from "components/base/OutboundLink";
 import Select from "components/base/Select";
 import React from "react";
 import styled from "styled-components";
@@ -46,8 +47,18 @@ export default function IflConfigurator(props) {
               />
             </svg>
           </div>
-          <div>&nbsp;Aller plus loin</div>
+          <div>&nbsp;Utiliser cette ressource</div>
         </GoFurther>
+        <p>
+          Utilisez les kits de diffusion Impact CO2 pour vous emparer facilement du simulateur et l’intégrer à votre
+          site.
+        </p>
+        <p>Besoin d'inspiration?</p>
+        <p>
+          <OutboundLink href="https://example.com" title="Découvrir des exemples de réutilisation – Nouvelle fenêtre">
+            Découvrez des exemples de réutilisation
+          </OutboundLink>
+        </p>
         <p>
           Pour réutiliser les données brutes ou obtenir de l'aide pour intégrer ce simulateur, contactez l’équipe
           à&nbsp;

--- a/src/components/modals/iflModal/IflConfigurator.js
+++ b/src/components/modals/iflModal/IflConfigurator.js
@@ -71,6 +71,7 @@ export default function IflConfigurator(props) {
           </OutboundLink>
         </p>
       </BottomAdvice>
+      <br />
       <details>
         <summary>Pour aller plus loin</summary>
         <p>
@@ -90,7 +91,7 @@ export default function IflConfigurator(props) {
 const BottomAdvice = styled.div`
   background-color: #ebf2ff;
   border-radius: 8px;
-  margin-top: auto;
+  margin-top: 2rem;
   padding: 24px;
   position: relative;
 `;


### PR DESCRIPTION
## User Story

ETQ relais de la ressource, je souhaite être accompagné·e dans le contenu que je diffuse à mes pairs.

## Description

- Suite aux réflexions que l’on a eu dans les développements de [[U5](https://www.notion.so/U5-Action-de-partage-du-simulateur-4aae67411f0240d888914acb4231f0e0?pvs=21)](https://www.notion.so/U5-Action-de-partage-du-simulateur-4aae67411f0240d888914acb4231f0e0?pvs=21), [[U6](https://www.notion.so/ddea26f22230472881dbd147d0cb713d?pvs=21)](https://www.notion.so/ddea26f22230472881dbd147d0cb713d?pvs=21), [[U7](https://www.notion.so/U7-Action-de-t-l-chargement-des-r-sultats-de-simulation-3f4f87d844cf4fffbd914ecfab46eb8b?pvs=21)](https://www.notion.so/U7-Action-de-t-l-chargement-des-r-sultats-de-simulation-3f4f87d844cf4fffbd914ecfab46eb8b?pvs=21)
- Afin d’accompagner au mieux la réutilisation des ressources, par l’exemple
- Dans le but aussi de valoriser toutes nos ressources et nos récents travaux
- En écho [[aux retours utilisateurs de l’enquête Maze](https://www.notion.so/057af496f2f94dbb9f770077905a3482?pvs=21)](https://www.notion.so/057af496f2f94dbb9f770077905a3482?pvs=21)

J’ai créé un ticket pour une v2 des fonctions de Partage et d’Intégration du simulateur et notamment du contenu de la modale qui valoriserait nos 2 nouvelles ressources qui semblent clés sur ces fonctions de diffusion : 

1- Kits de diffusions

2- Galerie des succès

## Maquettes

https://www.figma.com/file/zWtYlxvhrngEJsW5vQIahk/Impact-Livraison?type=design&node-id=548-8917&mode=design
    
<img width="348" alt="Screenshot 2023-08-01 at 09 04 23" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/5d8f3976-7924-494e-89f2-82bd9edd2f28">

    

## Checklist

- [ ]  Dans les modales “Intégrer le simulateur” et “Partager le simulateur”, j’ai bien une rubrique “Utiliser cette ressource” à la suite du contenu existant.
    


    
- [ ]  La rubrique “Utiliser cette ressource” contient deux liens qui redirigent vers le [[kit de diffusion](https://www.notion.so/b9d08930a49a4346830b7a12fd7cb733?pvs=21)](https://www.notion.so/b9d08930a49a4346830b7a12fd7cb733?pvs=21) sur Notion (lien 1) et la [[Galerie des succès](https://www.notion.so/2274283430e94d1db71eced54c338997?pvs=21)](https://www.notion.so/2274283430e94d1db71eced54c338997?pvs=21) (lien 2).
- [ ]  Les balises *<title>* des liens contiennent bien les mentions suivantes : “Voir les kits de diffusion Impact CO2 - Nouvelle fenêtre” et “Découvrir des exemples de réutilisation – Nouvelle fenêtre”.
- [ ]  Dans la modale “Intégrer le simulateur”, j’ai bien une rubrique “Aller plus loin” fixé en bas de la modale, replié.

<img width="325" alt="Screenshot 2023-08-01 at 09 04 49" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/f95d14ec-bec0-457b-8134-608bec3c980f">
    
- [ ]  Au clic sur la flèche à côté du titre “Aller plus loin”, les informations s’affichent.
    
<img width="322" alt="Screenshot 2023-08-01 at 09 05 20" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/b7611000-bdcf-4ca5-8b27-a9c7df08a5b2">

    
- [ ]  Accessibilité : au clavier, je peux naviguer de lien en lien dans la modale.
- [ ]  Accessibilité : au clic sur un lien, je suis bien redirigé vers le bon lien, ouvert dans un nouvel onglet.
- [ ]  Accessibilité : je peux à tout instant sortir de la modale en tabulant sur le bouton “Fermer”.
- [ ]  Accessibilité : au clic sur “Entrée” sur le bouton “Copier le lien” ou “Copier le code”, la copie s’effectue bien.

## Definition of Done

- [ ]  La fonctionnalité est accessible (@Laura).
- [ ]  La fonctionnalité a été recettée et validée en mobile / tablette.
- [ ]  La fonctionnalité a été recettée et validée en *dark-mode*.
- [ ]  La fonctionnalité correspond à l’attendu en termes Produit.
- [ ]  La fonctionnalité correspond à l’attendu en termes Design.