### PR TITLE
B9 - référencement google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.11 (04/09/2023)
+
+* B9 : référencement google
+
 ## 1.18.10 (04/09/2023)
 
 * BSR : tests de non-régression pour la partie livraison


### PR DESCRIPTION
## Description

Il semble y avoir un bug dans le référencement du site impact CO2 puisqu’on apparaît plus dans **les premières pages Google**

<img width="524" alt="Screenshot 2023-09-05 at 10 20 44" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/16bbe8c4-fae0-49ca-81e1-771b734e4aab">

<img width="481" alt="Screenshot 2023-09-05 at 10 20 53" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/37ab7e43-b127-41da-b026-2d20c56ec164">


⇒ @David Boureau est-ce que tu sais d’où pourrait venir le bug ? 
Est-ce qu’on voit quelque chose dans le search consol ? Est-ce que c’est lié à un meta tag/ meta image ? 
Est-ce qu’on doit se faire un point avec John ? 

## Definition of Done

- [ ]  La fonctionnalité est accessible (Laura).
- [ ]  La fonctionnalité a été recettée et validée en mobile / tablette.
- [ ]  La fonctionnalité a été recettée et validée en *dark-mode*.
- [ ]  La fonctionnalité correspond à l’attendu en termes Produit.
- [ ]  La fonctionnalité correspond à l’attendu en termes Design.