### PR TITLE
A26 - Modifier texte modale disclaimer stockage de données 1 Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.11 (04/09/2023)
+
+* A26 - Modifier texte modale disclaimer stockage de données 1 Go
+
 ## 1.18.10 (04/09/2023)
 
 * BSR : tests de non-régression pour la partie livraison


### PR DESCRIPTION
## Description

Suite de [[la A25](https://www.notion.so/A25-Afficher-une-modale-avec-un-disclaimer-sur-la-page-produit-Stockage-de-donn-es-1-Go-a725edd881e849d2b752a6891bc7e95e?pvs=21)](https://www.notion.so/A25-Afficher-une-modale-avec-un-disclaimer-sur-la-page-produit-Stockage-de-donn-es-1-Go-a725edd881e849d2b752a6891bc7e95e?pvs=21)

Retour métier sur le wording de la modale. 
Il faudrait donc modifier le texte en prenant en compte les modifs ci-dessous : 

Les données et les calculs sont issues du projet [[NégaOctet (lauréat de l'appel à projet PERFECTO 2018)](https://base-empreinte.ademe.fr/documentation/base-impact)](https://base-empreinte.ademe.fr/documentation/base-impact)

> ⚠️ **Attention** : aujourd’hui pour calculer l’impact carbone de Stocker un Go de données, nous ne prenons pas en compte dans nos calculs **l’impact carbone de la transmission** ~~ni celui **du stockage effectué par l'appareil,** puisque nous estimions que ce dernier étant partagé par beaucoup de personnes**,** était **amorti**~~. Ces calculs, expliquent la différence de résultat entre l'impact carbone que l’on a sur le site [[impactco2.fr](http://impactco2.fr/)](http://impactco2.fr/) et les données NO partagées sur la base Empreinte de l'ADEME. Nous mettrons prochainement à jour ces calculs pour intégrer la transmission. ~~travaillons à affiner ce calcul et à le mettre à jour.~~"
> 

## Definition of Done

- [ ]  La fonctionnalité est accessible (Laura).
- [ ]  La fonctionnalité a été recettée et validée en mobile / tablette.
- [ ]  La fonctionnalité a été recettée et validée en *dark-mode*.
- [ ]  La fonctionnalité correspond à l’attendu en termes Produit.
- [ ]  La fonctionnalité correspond à l’attendu en termes Design.