### PR TITLE
B3 - Affichage et usage mobile slider mails, visio et streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.12 (08/09/2023)
+
+* B3 : bug slider
+
 ## 1.18.11 (07/09/2023)
 
 * U25 : documentation publicode

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "next": "^13.1.6",
     "next-query-params": "^4.1.0",
     "next-sitemap": "^3.1.52",
+    "publicodes": "1.0.0-beta.72",
+    "publicodes-react": "1.0.0-beta.72",
     "puppeteer-core": "^19.6.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -39,6 +41,7 @@
     "react-highlight-words": "^0.20.0",
     "react-hotjar": "^5.4.1",
     "react-range": "^1.8.14",
+    "react-responsive-carousel": "^3.2.23",
     "react-share": "^4.4.1",
     "react-slick": "^0.29.0",
     "react-switch": "^7.0.0",
@@ -51,9 +54,7 @@
     "twemoji": "^14.0.2",
     "use-animate-number": "^1.0.5",
     "use-local-storage": "^3.0.0",
-    "use-query-params": "^2.2.0",
-    "publicodes": "1.0.0-beta.72",
-    "publicodes-react": "1.0.0-beta.72"
+    "use-query-params": "^2.2.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.33.0",

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -23,6 +23,14 @@ const Wrapper = styled.div`
   .carousel.carousel-slider {
     overflow: inherit;
   }
+  .carousel .control-dots {
+    bottom: -35px;
+  }
+  .carousel .control-dots .dot {
+    border: 1px solid black;
+    width: 12px;
+    height: 12px;
+  }
   .carousel .control-prev.control-arrow:before {
     border-right: 14px solid #39a69e;
   }

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -17,7 +17,32 @@ const devices = [
 
 const Wrapper = styled.div`
   margin-bottom: 1rem;
+  padding-left: 3rem;
+  padding-right: 3rem;
   width: 100%;
+  .carousel.carousel-slider {
+    overflow: inherit;
+  }
+  .carousel .control-prev.control-arrow:before {
+    border-right: 14px solid #39a69e;
+  }
+  .carousel .control-prev.control-arrow {
+    left: -35px;
+  }
+  .carousel .control-next.control-arrow:before {
+    border-left: 14px solid #39a69e;
+  }
+  .carousel .control-next.control-arrow {
+    right: -35px;
+  }
+  .carousel .control-arrow:before,
+  .carousel.carousel-slider .control-arrow:before {
+    border-bottom: 14px solid transparent;
+    border-top: 14px solid transparent;
+  }
+  .carousel.carousel-slider .control-arrow:hover {
+    background: inherit;
+  }
 `;
 
 const Slide = styled.div`
@@ -71,6 +96,13 @@ export default function DeviceInput(props) {
         centerMode={false}
         showArrows={true}
         useKeyboardArrows={true}
+        transitionTime={1}
+        infiniteLoop={true}
+        labels={{ leftArrow: "item précédent", rightArrow: "item suivant", item: "item" }}
+        onClickThumb={() => {
+          console.info("hello");
+        }}
+        showThumbs={false}
       >
         <Slide>
           <Label>Terminal utilisé</Label>

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -64,6 +64,9 @@ const Sliders = styled.div`
   display: flex;
   gap: 1.5rem;
   margin-bottom: 1.5rem;
+  ${(props) => props.theme.mq.medium} {
+    flex-direction: column;
+  }
 `;
 const Text = styled.p`
   font-size: ${(props) => (props.large ? 1 : 0.75)}rem;

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -4,7 +4,7 @@ import ButtonLink from "components/base/ButtonLink";
 import RulesContext from "components/numerique/RulesProvider";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
-import Slick from "react-slick";
+import Slider from "react-slick";
 import styled from "styled-components";
 
 const devices = [
@@ -79,8 +79,8 @@ export default function DeviceInput(props) {
 
   return (
     <Wrapper>
-      <Slick
-        dots={false}
+      <Slider
+        dots={true}
         infinite={true}
         speed={200}
         fade={true}
@@ -91,7 +91,7 @@ export default function DeviceInput(props) {
             [props.name + " . appareil"]: `'${devices[index - 1]?.name || "moyenne"}'`,
           });
         }}
-        touchMove={false}
+        touchMove={true}
         responsive={[
           {
             breakpoint: 830,
@@ -126,7 +126,7 @@ export default function DeviceInput(props) {
             </StyledButtonLink>
           </Slide>
         ))}
-      </Slick>
+      </Slider>
     </Wrapper>
   );
 }

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -15,6 +15,7 @@ const devices = [
 ];
 
 const Wrapper = styled.div`
+  margin-bottom: 1rem;
   width: 100%;
 
   .slick-track {
@@ -43,6 +44,7 @@ const Wrapper = styled.div`
     right: -1rem;
   }
 `;
+
 const Slide = styled.div`
   background-color: ${(props) => props.theme.colors.second};
   border: 0.0625rem solid ${(props) => props.theme.colors.second};

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -18,32 +18,6 @@ const devices = [
 const Wrapper = styled.div`
   margin-bottom: 1rem;
   width: 100%;
-
-  .slick-track {
-    display: flex !important;
-  }
-
-  .slick-slide {
-    height: inherit !important;
-
-    & > div {
-      height: 100%;
-    }
-  }
-  .slick-prev {
-    /* stylelint-disable-line */
-    background-image: url("data:image/svg+xml,%3Csvg width='27' height='31' viewBox='0 0 27 31' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 17.9187C-0.499999 16.764 -0.500001 13.8772 1.5 12.7225L22.5 0.598169C24.5 -0.556532 27 0.886842 27 3.19624L27 27.445C27 29.7544 24.5 31.1977 22.5 30.043L1.5 17.9187Z' fill='%23${(
-      props
-    ) => props.theme.colors.main.replace("#", "")}'/%3E%3C/svg%3E%0A");
-    left: -1rem;
-  }
-
-  .slick-next {
-    background-image: url("data:image/svg+xml,%3Csvg width='27' height='31' viewBox='0 0 27 31' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M25.5 12.7224C27.5 13.8771 27.5 16.7639 25.5 17.9186L4.5 30.0429C2.5 31.1976 -1.38802e-06 29.7543 -1.28708e-06 27.4449L-2.27131e-07 3.19616C-1.26184e-07 0.886754 2.5 -0.556626 4.5 0.598075L25.5 12.7224Z' fill='%23${(
-      props
-    ) => props.theme.colors.main.replace("#", "")}'/%3E%3C/svg%3E%0A");
-    right: -1rem;
-  }
 `;
 
 const Slide = styled.div`
@@ -52,7 +26,7 @@ const Slide = styled.div`
   border-radius: 1rem;
   height: 100%;
   padding: 1.5rem;
-  width: calc(50% - 1rem);
+  /* width: calc(50% - 1rem); */
 `;
 const Label = styled.label`
   display: block;
@@ -88,6 +62,15 @@ export default function DeviceInput(props) {
             [props.name + " . appareil"]: `'${devices[index - 1]?.name || "moyenne"}'`,
           });
         }}
+        statusFormatter={(currentItem, total) => {
+          return `${currentItem} sur ${total}`;
+        }}
+        swipeable={true}
+        emulateTouch={false}
+        autoFocus={true}
+        centerMode={false}
+        showArrows={true}
+        useKeyboardArrows={true}
       >
         <Slide>
           <Label>Terminal utilisé</Label>

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -4,7 +4,8 @@ import ButtonLink from "components/base/ButtonLink";
 import RulesContext from "components/numerique/RulesProvider";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
-import Slick from "react-slick";
+import { Carousel } from "react-responsive-carousel";
+import "react-responsive-carousel/lib/styles/carousel.min.css";
 import styled from "styled-components";
 
 const devices = [
@@ -29,8 +30,8 @@ const Wrapper = styled.div`
       height: 100%;
     }
   }
-
   .slick-prev {
+    /* stylelint-disable-line */
     background-image: url("data:image/svg+xml,%3Csvg width='27' height='31' viewBox='0 0 27 31' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 17.9187C-0.499999 16.764 -0.500001 13.8772 1.5 12.7225L22.5 0.598169C24.5 -0.556532 27 0.886842 27 3.19624L27 27.445C27 29.7544 24.5 31.1977 22.5 30.043L1.5 17.9187Z' fill='%23${(
       props
     ) => props.theme.colors.main.replace("#", "")}'/%3E%3C/svg%3E%0A");
@@ -64,9 +65,6 @@ const Sliders = styled.div`
   display: flex;
   gap: 1.5rem;
   margin-bottom: 1.5rem;
-  ${(props) => props.theme.mq.medium} {
-    flex-direction: column;
-  }
 `;
 const Text = styled.p`
   font-size: ${(props) => (props.large ? 1 : 0.75)}rem;
@@ -84,28 +82,12 @@ export default function DeviceInput(props) {
 
   return (
     <Wrapper>
-      <Slick
-        dots={true}
-        infinite={true}
-        speed={200}
-        fade={true}
-        slidesToShow={1}
-        slidesToScroll={1}
-        afterChange={(index) => {
+      <Carousel
+        onChange={(index) => {
           setSituation({
             [props.name + " . appareil"]: `'${devices[index - 1]?.name || "moyenne"}'`,
           });
         }}
-        touchMove={true}
-        responsive={[
-          {
-            breakpoint: 830,
-            settings: {
-              dots: true,
-              arrows: false,
-            },
-          },
-        ]}
       >
         <Slide>
           <Label>Terminal utilisé</Label>
@@ -131,7 +113,7 @@ export default function DeviceInput(props) {
             </StyledButtonLink>
           </Slide>
         ))}
-      </Slick>
+      </Carousel>
     </Wrapper>
   );
 }

--- a/src/components/numerique/equivalent/DeviceInput.js
+++ b/src/components/numerique/equivalent/DeviceInput.js
@@ -4,7 +4,7 @@ import ButtonLink from "components/base/ButtonLink";
 import RulesContext from "components/numerique/RulesProvider";
 import ModalContext from "components/providers/ModalProvider";
 import React, { useContext } from "react";
-import Slider from "react-slick";
+import Slick from "react-slick";
 import styled from "styled-components";
 
 const devices = [
@@ -79,7 +79,7 @@ export default function DeviceInput(props) {
 
   return (
     <Wrapper>
-      <Slider
+      <Slick
         dots={true}
         infinite={true}
         speed={200}
@@ -126,7 +126,7 @@ export default function DeviceInput(props) {
             </StyledButtonLink>
           </Slide>
         ))}
-      </Slider>
+      </Slick>
     </Wrapper>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,6 +5047,13 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-easy-swipe@^0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz#ce9384d576f7a8529dc2ca377c1bf03920bac8eb"
+  integrity sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-flip-toolkit@^7.0.17:
   version "7.0.17"
   resolved "https://registry.yarnpkg.com/react-flip-toolkit/-/react-flip-toolkit-7.0.17.tgz#2b330ab6ead76e82fa0b6a03c58b98a7cfe8ea0a"
@@ -5078,6 +5085,15 @@ react-range@^1.8.14:
   version "1.8.14"
   resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.8.14.tgz#11047f69b365ac6c75c3d715771ebe76b93982ec"
   integrity sha512-v2nyD5106rHf9dwHzq+WRlhCes83h1wJRHIMFjbZsYYsO6LF4mG/mR3cH7Cf+dkeHq65DItuqIbLn/3jjYjsHg==
+
+react-responsive-carousel@^3.2.23:
+  version "3.2.23"
+  resolved "https://registry.yarnpkg.com/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz#4c0016ff54603e604bb5c1f9e7ef2d1eda133f1d"
+  integrity sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.5.8"
+    react-easy-swipe "^0.0.21"
 
 react-share@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
## Description

Suite du ticket [[A8-A11Y](https://www.notion.so/A8-A11y-les-mouvements-automatiques-peuvent-tre-arr-t-s-01d1050496e646138973dc2b0d63cfee?pvs=21)](https://www.notion.so/A8-A11y-les-mouvements-automatiques-peuvent-tre-arr-t-s-01d1050496e646138973dc2b0d63cfee?pvs=21) : bugs identifiés lors de la R7 sur [[la pré-prod](https://develop--impactco2.netlify.app/livraison)](https://develop--impactco2.netlify.app/livraison) ainsi que sur la prod

Sur mobile on a des bugs d’affichage des sliders pour les pages des items : email, visioconférence, et streaming : 

- On a pas le même comportement que sur les autres infographies : **on ne peut pas slider vers la droite ou vers la gauche** il faut appuyer sur les points pour passer d’une slide à l’autre
- Et aussi on a un bug d’affichage, **le slider est coupé sur mobile**


<img width="597" alt="Screenshot 2023-09-05 at 10 16 16" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/aa9e90a9-b708-4253-b920-819cb40a33ae">

## Checklist (même comportement pour les 3 pages)

**Page streaming** 

- [ ]  Depuis la page item **streaming**, je visualise un carrousel d’infographies
    
<img width="251" alt="Screenshot 2023-09-05 at 10 16 28" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/fc6d570c-4942-43a3-9423-32d9925468e8">

    
- [ ]  Le nombre de points m’indiquent le nombres de slides : 5
    - Terminal utilisé
    - Smartphone
    - Tablette
    - Ordinateur portable
    - Ordinateur fixe
- [ ]  Je peux **swiper vers la droite ou vers la gauche** pour faire défiler les slides
- [ ]  Je visualise bien l’intégralité de chaque slide, sans coupure
- [ ]  Sur les slides 2, 3, 4 et 5 je peux jouer avec la durée de vie et la durée d’utilisation grâce à 2 sliders
- [ ]  Pour chaque appareil numérique, plus j’augmente la durée de vite plus l’impact carbone du streaming diminue
- [ ]  Plus j’augmente la durée d’utilisation, plus l’impact carbone du streaming diminue
- [ ]  Je visualise le lien **Ne plus afficher l’impact de la construction**
- [ ]  Au clique, la phase de construction est supprimée. Elle disparaît du graphique et l’impact carbone du streaming diminue.

**Page visoconférence** 

- [ ]  Depuis la page **Visioconférence**, je visualise un carrousel d’infographies
    
<img width="244" alt="Screenshot 2023-09-05 at 10 16 43" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/76807aab-84a1-4eeb-a2fb-b53be53b0859">

    
- [ ]  Le nombre de points m’indiquent le nombres de slides : 5
    - Terminal utilisé
    - Smartphone
    - Tablette
    - Ordinateur portable
    - Ordinateur fixe
- [ ]  Je peux swiper vers la droite ou vers la gauche pour faire défiler les slides
- [ ]  Je visualise bien l’intégralité de chaque slide, sans coupure
- [ ]  Sur les slides 2, 3, 4 et 5 je peux jouer avec la durée de vie et la durée d’utilisation grâce à 2 sliders
- [ ]  Pour chaque appareil numérique, plus j’augmente la durée de vite plus l’impact carbone de la visio avec pièce jointe diminue
- [ ]  Plus j’augmente la durée d’utilisation, plus l’impact carbone de la visio diminue
- [ ]  Je visualise le lien **Ne plus afficher l’impact de la construction**
- [ ]  Au clique, la phase de construction est supprimée. Elle disparaît du graphique et l’impact carbone de la visio diminue.

**Page mail** 

- [ ]  Depuis la page item E-mail, je visualise un carrousel d’infographies
- [ ]  Le nombre de points m’indiquent le nombres de slides : 5
    - Terminal utilisé
    - Smartphone
    - Tablette
    - Ordinateur portable
    - Ordinateur fixe
        
<img width="247" alt="Screenshot 2023-09-05 at 10 16 51" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/22b33a1d-f56e-4189-9bb3-55556bdc5c41">

        
- [ ]  Je peux swiper vers la droite ou vers la gauche pour faire défiler les slides
- [ ]  Je visualise bien l’intégralité de chaque slide, sans coupure
- [ ]  Sur les slides 2, 3, 4 et 5 je peux jouer avec la durée de vie et la durée d’utilisation grâce à 2 sliders
- [ ]  Pour chaque appareil numérique, plus j’augmente la durée de vite plus l’impact carbone de mon e-mail avec pièce jointe diminue
- [ ]  Plus j’augmente la durée d’utilisation, plus l’impact carbone de mon e-mail avec pj diminue
- [ ]  Je visualise le lien **Ne plus afficher l’impact de la construction**
- [ ]  Au clique, la phase de construction est supprimée. Elle disparaît du graphique comme ci-dessous et l’impact carbone du mail diminue.

<img width="443" alt="Screenshot 2023-09-05 at 10 17 12" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/bad135af-c705-4010-bca5-c87db6f8a8aa">

## Definition of Done

- [ ]  La fonctionnalité est accessible (Laura).
- [ ]  La fonctionnalité a été recettée et validée en mobile / tablette.
- [ ]  La fonctionnalité a été recettée et validée en *dark-mode*.
- [ ]  La fonctionnalité correspond à l’attendu en termes Produit.
- [ ]  La fonctionnalité correspond à l’attendu en termes Design.