### PR TITLE
U30 - Reprendre la page statistiques de Datagir sur impactCO2.fr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.11 (04/09/2023)
+
+* U30 - Reprendre la page statistiques de Datagir sur impactCO2.fr
+
 ## 1.18.10 (04/09/2023)
 
 * BSR : tests de non-régression pour la partie livraison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.10 (04/09/2023)
+
+* BSR : tests de non-régression pour la partie livraison
+
 ## 1.18.9 (11/08/2023)
 
 * B7 - bugs post-MEP : hotfix date mise à jour, et valeur stockage de données

--- a/src/components/livraison/YearlyLivraison.js
+++ b/src/components/livraison/YearlyLivraison.js
@@ -39,7 +39,7 @@ export default function YearlyLivraison(props) {
         </Induction>
         <Deduction>
           <span>alors cette livraison émets&nbsp;</span>
-          <Color>
+          <Color id="kgCo2e">
             {convertGramsToKilograms(props.co2eq * multiplicator * number)} kg CO<sub>2</sub>e
           </Color>
           <strong>&nbsp;par an&nbsp;</strong>.

--- a/src/components/misc/tiles/LivraisonEq.js
+++ b/src/components/misc/tiles/LivraisonEq.js
@@ -20,12 +20,14 @@ export default function LivraisonEq(props) {
       <EmojiWrapper>
         <Emoji>{props?.equivalent?.emoji}</Emoji>
       </EmojiWrapper>
-      <Number>{first2WordsOnly(fullSentenceFormat(props))}</Number>
+      <Number id={`eq_nb_${props.slug}`}>{first2WordsOnly(fullSentenceFormat(props))}</Number>
       <div></div>
-      <OfWhat>{first2WordsRemoved(fullSentenceFormat(props))}</OfWhat>
+      <OfWhat id={`eq_what_${props.slug}`}>{first2WordsRemoved(fullSentenceFormat(props))}</OfWhat>
       <div></div>
       <div>
-        <ButtonChange onClick={changeClicked}>Modifier l'équivalence</ButtonChange>
+        <ButtonChange onClick={changeClicked} id={`button_change_eq_${props.slug}`}>
+          Modifier l'équivalence
+        </ButtonChange>
       </div>
     </Wrapper>
   );

--- a/src/components/modals/tilesModal/EquivalentRadio.js
+++ b/src/components/modals/tilesModal/EquivalentRadio.js
@@ -42,7 +42,7 @@ const StyledEmoji = styled(Emoji)`
 `;
 export default function EquivalentRadio(props) {
   return (
-    <Wrapper checked={props.checked} onClick={() => props.setChecked(!props.checked)}>
+    <Wrapper checked={props.checked} onClick={() => props.setChecked(!props.checked)} className="equivalent-radio">
       <Left>
         <Radio checked={props.checked} />
 


### PR DESCRIPTION
## User Story

En tant qu’utilisateur lambda je veux pouvoir consulter les statiques du site Impact CO2.

En tant que membre de l’équipe Impact CO2 je veux pouvoir visualiser et retrouver rapidement les métriques clés du site Impact CO2  

## Description

Avec la disparition de Datagir et du site, il faudrait reprendre la page stat, uniquement la partie sur Impact CO2 et l’intégrer sur le site [[impactCO2.fr](http://impactco2.fr/)](http://impactCO2.fr) pour que l’on ait notre propre page [impactco2.fr/stats](http://impactco2.fr/stats)

Sur cette US l’idée est de simplement développer la page statistique d’impact CO2 en reprenant l’existant sur la page statistique de https://datagir.ademe.fr/stats/
J’ai créé [[une autre carte pour l’amélioration de cette page](https://www.notion.so/A13-Am-lioration-de-la-page-stats-Impact-CO2-016df723ca1b47f7951068b0ba975e16?pvs=21)](https://www.notion.so/A13-Am-lioration-de-la-page-stats-Impact-CO2-016df723ca1b47f7951068b0ba975e16?pvs=21) stat qui viendra dans un temps 2 

## Checklist

- [ ]  J’ai accès à l’URL https://impactco2.fr/stats
- [ ]  J’ai accès également à cette page depuis le footer du site Impact CO2 sous le lien “Statistiques”
    
<img width="592" alt="Screenshot 2023-09-05 at 10 11 31" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/1e499f2d-b2f3-4f00-b84d-f060194397cc">

    

- [ ]  Je visualise le nombre de visites en fonction de la période. Je peux affiner la période en fonction du nombre (1 à 31) et de la temporalité (jours, semaines, mois)
- [ ]  La checkbox *Cacher les visites venant de [[datagir.ademe.fr](http://datagir.ademe.fr/)](http://datagir.ademe.fr)* n’existe plus.
- [ ]  Je visualise graphiquement la durée des visites sur la même période définie précédemment.
- [ ]  Je visualise sous forme de tableau l’origine des visites : Top 10 des sites web qui nous amènent du traffic, le traffic / réseaux sociaux, et enfin le traffic généré par des recherches de mots clés indéfini

<img width="588" alt="Screenshot 2023-09-05 at 10 12 00" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/289f97d4-301e-4b22-8834-d39c97357ef2">

<img width="559" alt="Screenshot 2023-09-05 at 10 12 11" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/4f377419-95b1-40bc-9937-66110f38b7bd">

<img width="600" alt="Screenshot 2023-09-05 at 10 12 23" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/9b85ebbc-6fbc-4f3f-9b1a-646f7974a8f8">

## Definition of Done

- [ ]  La fonctionnalité est accessible (Laura).
- [ ]  La fonctionnalité a été recettée et validée en mobile / tablette.
- [ ]  La fonctionnalité a été recettée et validée en *dark-mode*.
- [ ]  La fonctionnalité correspond à l’attendu en termes Produit.
- [ ]  La fonctionnalité correspond à l’attendu en termes Design.