### PR TITLE
U21 - Recette UI Impact Livraison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.11 (04/09/2023)
+
+* U21 – Recette UI Impact Livraison
+
 ## 1.18.10 (04/09/2023)
 
 * BSR : tests de non-régression pour la partie livraison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # CHANGELOG
 
 
+## 1.18.10 (04/09/2023)
+
+* BSR : tests de non-régression pour la partie livraison
+
 ## 1.18.9 (11/08/2023)
 
 * B7 - bugs post-MEP : hotfix date mise à jour, et valeur stockage de données

--- a/src/components/livraison/YearlyLivraison.js
+++ b/src/components/livraison/YearlyLivraison.js
@@ -39,7 +39,7 @@ export default function YearlyLivraison(props) {
         </Induction>
         <Deduction>
           <span>alors cette livraison émets&nbsp;</span>
-          <Color>
+          <Color id="kgCo2e">
             {convertGramsToKilograms(props.co2eq * multiplicator * number)} kg CO<sub>2</sub>e
           </Color>
           <strong>&nbsp;par an&nbsp;</strong>.

--- a/src/components/misc/tiles/LivraisonEq.js
+++ b/src/components/misc/tiles/LivraisonEq.js
@@ -20,12 +20,14 @@ export default function LivraisonEq(props) {
       <EmojiWrapper>
         <Emoji>{props?.equivalent?.emoji}</Emoji>
       </EmojiWrapper>
-      <Number>{first2WordsOnly(fullSentenceFormat(props))}</Number>
+      <Number id={`eq_nb_${props.slug}`}>{first2WordsOnly(fullSentenceFormat(props))}</Number>
       <div></div>
-      <OfWhat>{first2WordsRemoved(fullSentenceFormat(props))}</OfWhat>
+      <OfWhat id={`eq_what_${props.slug}`}>{first2WordsRemoved(fullSentenceFormat(props))}</OfWhat>
       <div></div>
       <div>
-        <ButtonChange onClick={changeClicked}>Modifier l'équivalence</ButtonChange>
+        <ButtonChange onClick={changeClicked} id={`button_change_eq_${props.slug}`}>
+          Modifier l'équivalence
+        </ButtonChange>
       </div>
     </Wrapper>
   );

--- a/src/components/modals/tilesModal/EquivalentRadio.js
+++ b/src/components/modals/tilesModal/EquivalentRadio.js
@@ -42,7 +42,7 @@ const StyledEmoji = styled(Emoji)`
 `;
 export default function EquivalentRadio(props) {
   return (
-    <Wrapper checked={props.checked} onClick={() => props.setChecked(!props.checked)}>
+    <Wrapper checked={props.checked} onClick={() => props.setChecked(!props.checked)} className="equivalent-radio">
       <Left>
         <Radio checked={props.checked} />
 


### PR DESCRIPTION
- [ ]  ***Header***
L’architecture du site doit être similaire entre la page actuelle et les autres pages du site.

<img width="607" alt="Screenshot 2023-09-04 at 16 40 43" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/d2e40a8a-6529-4556-8317-6c379b3c228b">    

- [ ]  ***Header***
Les icônes sont un peu “dodues”, à voir si on peut les affiner ou du moins passer l’icône “soleil” en version “contours” au lieu de la version pleine, si ça existe.
    
<img width="199" alt="Screenshot 2023-09-04 at 16 40 53" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/c76ffc07-9e95-47a0-86e0-525411c1e276">
    

- [ ]  En version mobile, les sélecteurs peuvent prendre toute la largeur.
    
<img width="566" alt="Screenshot 2023-09-04 at 16 41 11" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/6ba01487-0013-42d4-a79e-ad3085ea6b63">
    
- [ ]  Lorsque l’élément de la liste “vous commandez en majorité” est “bien d’équimement volumineux”, le contenu n’est pas affiché en entier.
    
<img width="515" alt="Screenshot 2023-09-04 at 16 41 36" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/2ea4e8d5-0d2b-4b14-bf46-1cdf03cc5181">
    
- [ ]  **UI**

La source et date de mise à jour devraient être dans un ton de gris plus clair que le texte. Changer pour #564D53.
    
<img width="580" alt="Screenshot 2023-09-04 at 16 42 06" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/af7a618f-0445-4d3d-92ac-6659928616f9">    

- [ ]  **UI #RetourDeDesignerRelou**

Le *border-radius* du contour n’a pas le même arrondi que celui du bloc bleu (voir les coins).
    
<img width="566" alt="Screenshot 2023-09-04 at 16 42 33" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/94861c3d-bf7e-43ee-b0b4-762b404ec80d">
    
- [ ]  **UI** 
”kg de CO2e” devrait idéalement passer sur une seule ligne en version *desktop*.
- [ ]  **UI** 
Peut-on envisager de fixer l’icône de la petite pousse en haut au lieu de centrée sur le “xxx de CO2e” ?
- [ ]  **UI – Manque d’arrondis sur les options**
Ajouter un border radius 8px sur la zone grise en bas à droite et gauche.

<img width="600" alt="Screenshot 2023-09-04 at 16 42 59" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/06aca80c-712f-45fa-8349-f3a46999cbf2">

    
- [ ]  **UI – La taille des icônes n’est pas la même entre les équivalents**

Idéalement, les fixer à 24px max, toutes.
    
<img width="605" alt="Screenshot 2023-09-04 at 16 44 17" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/798c693c-4537-4f69-b9a6-6b4bb2c70b6d">
    
- [ ]  **UI - le select des modes de déplacement Grignotte le reste du texte**

<img width="605" alt="Screenshot 2023-09-04 at 16 45 23" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/3da80db7-44f0-4927-963f-5c3a7e9ea23e">


- [ ]  **UI – les interrupteurs sont un peu dodus, à rétrécir**
    
<img width="179" alt="Screenshot 2023-09-04 at 16 45 41" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/8a407eaf-0a2a-487d-9b09-a8c6bf087f65">

    
- [ ]  **UI – les zones bleues doivent avoir une largeur fixe**
    
<img width="141" alt="Screenshot 2023-09-04 at 16 45 56" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/81f55d88-207b-482a-8a87-110fec2f9c3d">
    
<img width="151" alt="Screenshot 2023-09-04 at 16 46 11" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/73d81ceb-39e0-4e5d-b471-810aa6c7e6a0">
    
- [ ]  **UI – les tags de Kg de CO2e additionnels liés au choix du transport et / km ne rendent pas bien sur mobile. C’est sur 2 lignes et pas très esthétique**

<img width="274" alt="Screenshot 2023-09-04 at 16 46 54" src="https://github.com/incubateur-ademe/impactco2/assets/2937888/c430dd1f-4cba-4245-bcf9-e40b3ede8d0d">
